### PR TITLE
Code identation on the help html files

### DIFF
--- a/src/help/en/AAA.htm
+++ b/src/help/en/AAA.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>AAA.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> AAA - ASCII Adjust After Addition<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> AAA<br>
-			<strong>Effects:</strong> AAA should be used after a one-byte ADD instruction whose destination was the AL register: by means of examining the value in the low nibble of AL and also the auxiliary carry flag AF, it determines whether the addition has overflowed, and adjusts it (and sets the carry flag) if so. You can add long BCD strings together by doing ADD/AAA on the low digits, then doing ADC/AAA on each subsequent digit.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=1 when addition has overflowed
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>AAA.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> AAA - ASCII Adjust After Addition<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> AAA<br>
+    <strong>Effects:</strong> AAA should be used after a one-byte ADD instruction whose destination was the AL register: by means of examining the value in the low nibble of AL and also the auxiliary carry flag AF, it determines whether the addition has overflowed, and adjusts it (and sets the carry flag) if so. You can add long BCD strings together by doing ADD/AAA on the low digits, then doing ADC/AAA on each subsequent digit.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=1 when addition has overflowed
+</div>
+</body>
+</html>
 			

--- a/src/help/en/AAD.htm
+++ b/src/help/en/AAD.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>AAD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> AAD - ASCII Adjust AX Before Division<br>
-			<strong>Arguments:</strong> imm: mulitplier for AL, 10 if not specified<br>
-			<strong>Usage:</strong> AAD | AAD imm<br>
-			<strong>Effects:</strong> AAD performs the inverse operation to AAM: it multiplies AH by ten, adds it to AL, and sets AH to zero. Again, the multiplier 10 can be changed.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>AAD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> AAD - ASCII Adjust AX Before Division<br>
+    <strong>Arguments:</strong> imm: mulitplier for AL, 10 if not specified<br>
+    <strong>Usage:</strong> AAD | AAD imm<br>
+    <strong>Effects:</strong> AAD performs the inverse operation to AAM: it multiplies AH by ten, adds it to AL, and sets AH to zero. Again, the multiplier 10 can be changed.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/AAM.htm
+++ b/src/help/en/AAM.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>AAM.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> AAM - ASCII Adjust AX After Multiply<br>
-			<strong>Arguments:</strong> imm: divisor for AL, 10 if not specified<br>
-			<strong>Usage:</strong> AAM | AAM imm<br>
-			<strong>Effects:</strong> AAM is for use after you have multiplied two decimal digits together and left the result in AL: it divides AL by ten and stores the quotient in AH, leaving the remainder in AL. The divisor 10 can be changed by specifying an operand to the instruction: a particularly handy use of this is AAM 16, causing the two nibbles in AL to be separated into AH and AL.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>AAM.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> AAM - ASCII Adjust AX After Multiply<br>
+    <strong>Arguments:</strong> imm: divisor for AL, 10 if not specified<br>
+    <strong>Usage:</strong> AAM | AAM imm<br>
+    <strong>Effects:</strong> AAM is for use after you have multiplied two decimal digits together and left the result in AL: it divides AL by ten and stores the quotient in AH, leaving the remainder in AL. The divisor 10 can be changed by specifying an operand to the instruction: a particularly handy use of this is AAM 16, causing the two nibbles in AL to be separated into AH and AL.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/AAS.htm
+++ b/src/help/en/AAS.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>AAS.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> AAS - ASCII Adjust AL After Subtraction<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> AAS<br>
-			<strong>Effects:</strong> AAS works similarly to AAA, but is for use after SUB instructions rather than ADD.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=1 when substraction has overflowed
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>AAS.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> AAS - ASCII Adjust AL After Subtraction<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> AAS<br>
+    <strong>Effects:</strong> AAS works similarly to AAA, but is for use after SUB instructions rather than ADD.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=1 when substraction has overflowed
+</div>
+</body>
+</html>
 			

--- a/src/help/en/ADC.htm
+++ b/src/help/en/ADC.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>ADC.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> ADC-Add with Carry<br>
-			<strong>Arguments:</strong> DEST: register or memory location; SRC: immediate, register or memory location; (two memory operands cannot be used in one instruction)<br>
-			<strong>Usage:</strong> ADC DEST,SRC<br>
-			<strong>Effects:</strong> DEST := DEST + SRC + CF;<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The OF, SF, ZF, AF, CF, and PF flags are set according to the result.
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>ADC.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> ADC-Add with Carry<br>
+    <strong>Arguments:</strong> DEST: register or memory location; SRC: immediate, register or memory location; (two memory operands cannot be used in one instruction)<br>
+    <strong>Usage:</strong> ADC DEST,SRC<br>
+    <strong>Effects:</strong> DEST := DEST + SRC + CF;<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The OF, SF, ZF, AF, CF, and PF flags are set according to the result.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/ADD.htm
+++ b/src/help/en/ADD.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>ADD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> ADD-Integer Addition<br>
-			<strong>Arguments:</strong> DEST: register or memory location; SRC: immediate, register or memory location; (two memory operands cannot be used)<br>
-			<strong>Usage:</strong> ADD DEST,SRC<br>
-			<strong>Effects:</strong> DEST := DEST + SRC;<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The OF, SF, ZF, AF, CF, and PF flags are set according to the result.
-			<br><strong>Misc:</strong> No difference between signed and unsigned operands. OF and CF flags indicate carry in case of unsigned and signed values, SF indicates the sign in case of signed values.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>ADD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> ADD-Integer Addition<br>
+    <strong>Arguments:</strong> DEST: register or memory location; SRC: immediate, register or memory location; (two memory operands cannot be used)<br>
+    <strong>Usage:</strong> ADD DEST,SRC<br>
+    <strong>Effects:</strong> DEST := DEST + SRC;<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The OF, SF, ZF, AF, CF, and PF flags are set according to the result.
+    <br><strong>Misc:</strong> No difference between signed and unsigned operands. OF and CF flags indicate carry in case of unsigned and signed values, SF indicates the sign in case of signed values.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/AND.htm
+++ b/src/help/en/AND.htm
@@ -1,19 +1,18 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>AND.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> AND - Logical and<br>
-			<strong>Arguments:</strong> DEST: register or memory location; SRC: immediate, register or memory location; (two memory operands cannot be used in one instruction)<br>
-			<strong>Usage:</strong> AND DEST,SRC<br>
-			<strong>Effects:</strong> DEST := DEST and SRC
-Performs bitwise and of DEST and SRC
-<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF, ZF, SF, ZF, PF
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>AND.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> AND - Logical and<br>
+    <strong>Arguments:</strong> DEST: register or memory location; SRC: immediate, register or memory location; (two memory operands cannot be used in one instruction)<br>
+    <strong>Usage:</strong> AND DEST,SRC<br>
+    <strong>Effects:</strong> DEST := DEST and SRC
+    Performs bitwise and of DEST and SRC
+    <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF, CF, SF, ZF, PF
+</div>
+</body>
+</html>
 			

--- a/src/help/en/BSF.htm
+++ b/src/help/en/BSF.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>BSF.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> BSF - Bit Scan<br>
-			<strong>Arguments:</strong> DEST: register (16 or 32 bit); SRC = register/memory (16 or 32 bit)<br>
-			<strong>Usage:</strong> BSF DEST,SRC<br>
-			<strong>Effects:</strong> BSF searches for the least significant set bit in its source (second) operand, and if it finds one, stores the index in its destination (first) operand. If no set bit is found, the contents of the destination operand are undefined. If the source operand is zero, the zero flag is set.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> ZF=1 if SRC = 0
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>BSF.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> BSF - Bit Scan<br>
+    <strong>Arguments:</strong> DEST: register (16 or 32 bit); SRC = register/memory (16 or 32 bit)<br>
+    <strong>Usage:</strong> BSF DEST,SRC<br>
+    <strong>Effects:</strong> BSF searches for the least significant set bit in its source (second) operand, and if it finds one, stores the index in its destination (first) operand. If no set bit is found, the contents of the destination operand are undefined. If the source operand is zero, the zero flag is set.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> ZF=1 if SRC = 0
+</div>
+</body>
+</html>
 			

--- a/src/help/en/BSR.htm
+++ b/src/help/en/BSR.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>BSR.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> BSR - Bit Scan<br>
-			<strong>Arguments:</strong> DEST: register (16 or 32 bit); SRC = register/memory (16 or 32 bit)<br>
-			<strong>Usage:</strong> BSR DEST,SRC<br>
-			<strong>Effects:</strong> BSR searches for the most significant set bit in its source (second) operand, and if it finds one, stores the index in its destination (first) operand. If no set bit is found, the contents of the destination operand are undefined. If the source operand is zero, the zero flag is set.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> ZF=1 if SRC = 0
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>BSR.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> BSR - Bit Scan<br>
+    <strong>Arguments:</strong> DEST: register (16 or 32 bit); SRC = register/memory (16 or 32 bit)<br>
+    <strong>Usage:</strong> BSR DEST,SRC<br>
+    <strong>Effects:</strong> BSR searches for the most significant set bit in its source (second) operand, and if it finds one, stores the index in its destination (first) operand. If no set bit is found, the contents of the destination operand are undefined. If the source operand is zero, the zero flag is set.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> ZF=1 if SRC = 0
+</div>
+</body>
+</html>
 			

--- a/src/help/en/BSWAP.htm
+++ b/src/help/en/BSWAP.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>BSWAP.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> BSWAP - Byteswap<br>
-			<strong>Arguments:</strong> REG: register (32 bit)<br>
-			<strong>Usage:</strong> BSWAP REG<br>
-			<strong>Effects:</strong> BSWAP swaps the order of the four bytes of a 32-bit register: bits 0-7 exchange places with bits 24-31, and bits 8-15 swap with bits 16-23. There is no explicit 16-bit equivalent: to byte-swap AX, BX, CX or DX, XCHG can be used.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> When BSWAP is used with a 16-bit register, the result is undefined.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>BSWAP.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> BSWAP - Byteswap<br>
+    <strong>Arguments:</strong> REG: register (32 bit)<br>
+    <strong>Usage:</strong> BSWAP REG<br>
+    <strong>Effects:</strong> BSWAP swaps the order of the four bytes of a 32-bit register: bits 0-7 exchange places with bits 24-31, and bits 8-15 swap with bits 16-23. There is no explicit 16-bit equivalent: to byte-swap AX, BX, CX or DX, XCHG can be used.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> When BSWAP is used with a 16-bit register, the result is undefined.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/BT.htm
+++ b/src/help/en/BT.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>BT.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> BT - Bit Test<br>
-			<strong>Arguments:</strong> SRC: register; INDEX: index of a bit in SRC<br>
-			<strong>Usage:</strong> BT SRC,INDEX<br>
-			<strong>Effects:</strong> Tests one bit of its first operand, whose index is given by the second operand, and stores the value of that bit into the carry flag. Bit indices are from 0 (least significant) to 15 or 31 (most significant).<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=bit with given index
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>BT.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> BT - Bit Test<br>
+    <strong>Arguments:</strong> SRC: register; INDEX: index of a bit in SRC<br>
+    <strong>Usage:</strong> BT SRC,INDEX<br>
+    <strong>Effects:</strong> Tests one bit of its first operand, whose index is given by the second operand, and stores the value of that bit into the carry flag. Bit indices are from 0 (least significant) to 15 or 31 (most significant).<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=bit with given index
+</div>
+</body>
+</html>
 			

--- a/src/help/en/BTC.htm
+++ b/src/help/en/BTC.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>BTC.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> BTC - Bit Test<br>
-			<strong>Arguments:</strong> SRC: register; INDEX: index of a bit in SRC<br>
-			<strong>Usage:</strong> BTC SRC,INDEX<br>
-			<strong>Effects:</strong> Tests one bit of its first operand, whose index is given by the second operand, and stores the value of that bit into the carry flag. Bit indices are from 0 (least significant) to 15 or 31 (most significant). BTC also complements the bit in the first operand.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=bit with given index
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>BTC.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> BTC - Bit Test<br>
+    <strong>Arguments:</strong> SRC: register; INDEX: index of a bit in SRC<br>
+    <strong>Usage:</strong> BTC SRC,INDEX<br>
+    <strong>Effects:</strong> Tests one bit of its first operand, whose index is given by the second operand, and stores the value of that bit into the carry flag. Bit indices are from 0 (least significant) to 15 or 31 (most significant). BTC also complements the bit in the first operand.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=bit with given index
+</div>
+</body>
+</html>
 			

--- a/src/help/en/BTR.htm
+++ b/src/help/en/BTR.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>BTR.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> BTR - Bit Test<br>
-			<strong>Arguments:</strong> SRC: register; INDEX: index of a bit in SRC<br>
-			<strong>Usage:</strong> BTR SRC,INDEX<br>
-			<strong>Effects:</strong> Tests one bit of its first operand, whose index is given by the second operand, and stores the value of that bit into the carry flag. Bit indices are from 0 (least significant) to 15 or 31 (most significant). BTR also resets (clears) the bit in the operand itself.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=bit with given index
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>BTR.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> BTR - Bit Test<br>
+    <strong>Arguments:</strong> SRC: register; INDEX: index of a bit in SRC<br>
+    <strong>Usage:</strong> BTR SRC,INDEX<br>
+    <strong>Effects:</strong> Tests one bit of its first operand, whose index is given by the second operand, and stores the value of that bit into the carry flag. Bit indices are from 0 (least significant) to 15 or 31 (most significant). BTR also resets (clears) the bit in the operand itself.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=bit with given index
+</div>
+</body>
+</html>
 			

--- a/src/help/en/BTS.htm
+++ b/src/help/en/BTS.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>BTS.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> BTS - Bit Test<br>
-			<strong>Arguments:</strong> SRC: register; INDEX: index of a bit in SRC<br>
-			<strong>Usage:</strong> BTS SRC,INDEX<br>
-			<strong>Effects:</strong> Tests one bit of its first operand, whose index is given by the second operand, and stores the value of that bit into the carry flag. Bit indices are from 0 (least significant) to 15 or 31 (most significant). BTS also sets the bit in the operand itself.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=bit with given index
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>BTS.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> BTS - Bit Test<br>
+    <strong>Arguments:</strong> SRC: register; INDEX: index of a bit in SRC<br>
+    <strong>Usage:</strong> BTS SRC,INDEX<br>
+    <strong>Effects:</strong> Tests one bit of its first operand, whose index is given by the second operand, and stores the value of that bit into the carry flag. Bit indices are from 0 (least significant) to 15 or 31 (most significant). BTS also sets the bit in the operand itself.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=bit with given index
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CALL.htm
+++ b/src/help/en/CALL.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CALL.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CALL-Call Procedure<br>
-			<strong>Arguments:</strong> DEST (target): Adress of the first command of the called procedure; can be an immediate value, a general purpose register or a memory location<br>
-			<strong>Usage:</strong> CALL DEST<br>
-			<strong>Effects:</strong> Actual value of the instruction counter is saved on the stack and the instruction counter is set to the target adresse in order to go on with the called procedure.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> Usually there is a RET command in the procedure to return to the command after the call command.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CALL.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CALL-Call Procedure<br>
+    <strong>Arguments:</strong> DEST (target): Adress of the first command of the called procedure; can be an immediate value, a general purpose register or a memory location<br>
+    <strong>Usage:</strong> CALL DEST<br>
+    <strong>Effects:</strong> Actual value of the instruction counter is saved on the stack and the instruction counter is set to the target adresse in order to go on with the called procedure.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> Usually there is a RET command in the procedure to return to the command after the call command.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CBW.htm
+++ b/src/help/en/CBW.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CBW.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CBW - Sign extension<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> CBW<br>
-			<strong>Effects:</strong> CBW extends AL into AX by repeating the top bit of AL in every bit of AH<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CBW.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CBW - Sign extension<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> CBW<br>
+    <strong>Effects:</strong> CBW extends AL into AX by repeating the top bit of AL in every bit of AH<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CDQ.htm
+++ b/src/help/en/CDQ.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CDQ.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CDQ - Sign Extension<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> CDQ<br>
-			<strong>Effects:</strong> CDQ extends EAX into EDX:EAX by repeating the top bit of EAX.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CDQ.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CDQ - Sign Extension<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> CDQ<br>
+    <strong>Effects:</strong> CDQ extends EAX into EDX:EAX by repeating the top bit of EAX.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CLC.htm
+++ b/src/help/en/CLC.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CLC.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CLC - Clear Carry Flag<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> CLC<br>
-			<strong>Effects:</strong> CLC clears the carry flag<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=0
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CLC.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CLC - Clear Carry Flag<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> CLC<br>
+    <strong>Effects:</strong> CLC clears the carry flag<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=0
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CLD.htm
+++ b/src/help/en/CLD.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CLD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CLD - Clear Direction Flag<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> CLD<br>
-			<strong>Effects:</strong> CLD clears the direction flag<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> DF=0
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CLD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CLD - Clear Direction Flag<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> CLD<br>
+    <strong>Effects:</strong> CLD clears the direction flag<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> DF=0
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMC.htm
+++ b/src/help/en/CMC.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMC.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMC - Change Carry Flag<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> CMC<br>
-			<strong>Effects:</strong> CMC changes the value of the carry flag: if it was 0, it sets it to 1, and vice versa.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=0 if CF=1; CF=1 if CF=0
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMC.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMC - Change Carry Flag<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> CMC<br>
+    <strong>Effects:</strong> CMC changes the value of the carry flag: if it was 0, it sets it to 1, and vice versa.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=0 if CF=1; CF=1 if CF=0
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVA.htm
+++ b/src/help/en/CMOVA.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVA.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVA - Move if above (CF=0 and ZF=0)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVA DEST,SRC<br>
-			<strong>Effects:</strong> If (CF=0 and ZF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag and zeroflag are not set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVA.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVA - Move if above (CF=0 and ZF=0)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVA DEST,SRC<br>
+    <strong>Effects:</strong> If (CF=0 and ZF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag and zeroflag are not set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVAE.htm
+++ b/src/help/en/CMOVAE.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVAE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVAE - Move if above or equal (CF=0)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVAE DEST,SRC<br>
-			<strong>Effects:</strong> If (CF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag is not set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVAE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVAE - Move if above or equal (CF=0)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVAE DEST,SRC<br>
+    <strong>Effects:</strong> If (CF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag is not set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVB.htm
+++ b/src/help/en/CMOVB.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVB.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVB - Move if below (CF=1)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVB DEST,SRC<br>
-			<strong>Effects:</strong> If (CF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag is set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVB.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVB - Move if below (CF=1)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVB DEST,SRC<br>
+    <strong>Effects:</strong> If (CF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag is set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVBE.htm
+++ b/src/help/en/CMOVBE.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVBE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVBE - Move if below or equal (CF=1 or ZF=1)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVBE DEST,SRC<br>
-			<strong>Effects:</strong> If (CF=1 or ZF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag or zeroflag is set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVBE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVBE - Move if below or equal (CF=1 or ZF=1)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVBE DEST,SRC<br>
+    <strong>Effects:</strong> If (CF=1 or ZF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag or zeroflag is set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVC.htm
+++ b/src/help/en/CMOVC.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVC.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVC - Move if carry (CF=1)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVC DEST,SRC<br>
-			<strong>Effects:</strong> If (CF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag is set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVC.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVC - Move if carry (CF=1)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVC DEST,SRC<br>
+    <strong>Effects:</strong> If (CF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag is set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVE.htm
+++ b/src/help/en/CMOVE.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVE - Move if equal (ZF=1)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVE DEST,SRC<br>
-			<strong>Effects:</strong> If (ZF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if zeroflag is set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVE - Move if equal (ZF=1)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVE DEST,SRC<br>
+    <strong>Effects:</strong> If (ZF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if zeroflag is set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVG.htm
+++ b/src/help/en/CMOVG.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVG.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVG - Move if greater (ZF=0 and SF=OF)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVG DEST,SRC<br>
-			<strong>Effects:</strong> If (ZF=0 and SF=OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if zeroflag is not set and signflag and overflowflag are equal. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVG.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVG - Move if greater (ZF=0 and SF=OF)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVG DEST,SRC<br>
+    <strong>Effects:</strong> If (ZF=0 and SF=OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if zeroflag is not set and signflag and overflowflag are equal. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVGE.htm
+++ b/src/help/en/CMOVGE.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVGE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVGE - Move if greater or equal (SF=OF)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVGE DEST,SRC<br>
-			<strong>Effects:</strong> If (SF=OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if signflag and overflowflag are equal. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVGE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVGE - Move if greater or equal (SF=OF)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVGE DEST,SRC<br>
+    <strong>Effects:</strong> If (SF=OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if signflag and overflowflag are equal. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVL.htm
+++ b/src/help/en/CMOVL.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVL.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVL - Move if less (SF<>OF)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVL DEST,SRC<br>
-			<strong>Effects:</strong> If (SF<>OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if signflag and overflowflag are not equal. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVL.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVL - Move if less (SF<>OF)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVL DEST,SRC<br>
+    <strong>Effects:</strong> If (SF<>OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if signflag and overflowflag are not equal. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVLE.htm
+++ b/src/help/en/CMOVLE.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVLE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVLE - Move if less or equal (ZF=1 or SF<>OF)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVLE DEST,SRC<br>
-			<strong>Effects:</strong> If (ZF=1 or SF<>OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if signflag and overflowflag are not equal or zeroflag is not set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVLE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVLE - Move if less or equal (ZF=1 or SF<>OF)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVLE DEST,SRC<br>
+    <strong>Effects:</strong> If (ZF=1 or SF<>OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if signflag and overflowflag are not equal or zeroflag is not set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVNA.htm
+++ b/src/help/en/CMOVNA.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVNA.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVNA - Move if not above (CF=1 or ZF=1)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVNA DEST,SRC<br>
-			<strong>Effects:</strong> If (CF=1 and ZF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag and zeroflag are set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVNA.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVNA - Move if not above (CF=1 or ZF=1)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVNA DEST,SRC<br>
+    <strong>Effects:</strong> If (CF=1 and ZF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag and zeroflag are set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVNAE.htm
+++ b/src/help/en/CMOVNAE.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVNAE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVNAE - Move if not above or equal (CF=1)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVNAE DEST,SRC<br>
-			<strong>Effects:</strong> If (CF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag is set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVNAE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVNAE - Move if not above or equal (CF=1)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVNAE DEST,SRC<br>
+    <strong>Effects:</strong> If (CF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag is set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVNB.htm
+++ b/src/help/en/CMOVNB.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVNB.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVNB - Move if not below (CF=0)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVNB DEST,SRC<br>
-			<strong>Effects:</strong> If (CF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag is not set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVNB.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVNB - Move if not below (CF=0)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVNB DEST,SRC<br>
+    <strong>Effects:</strong> If (CF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag is not set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVNBE.htm
+++ b/src/help/en/CMOVNBE.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVNBE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVNBE - Move if not below or equal (CF=0 and ZF=0)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVNBE DEST,SRC<br>
-			<strong>Effects:</strong> If (CF=0 and ZF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag and zeroflag are not set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVNBE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVNBE - Move if not below or equal (CF=0 and ZF=0)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVNBE DEST,SRC<br>
+    <strong>Effects:</strong> If (CF=0 and ZF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag and zeroflag are not set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVNC.htm
+++ b/src/help/en/CMOVNC.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVNC.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVNC Move if not carry (CF=0)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVNC DEST,SRC<br>
-			<strong>Effects:</strong> If (CF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag is not set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVNC.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVNC Move if not carry (CF=0)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVNC DEST,SRC<br>
+    <strong>Effects:</strong> If (CF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag is not set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVNE.htm
+++ b/src/help/en/CMOVNE.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVNE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVNE - Move if not equal (ZF=0)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVNE DEST,SRC<br>
-			<strong>Effects:</strong> If (ZF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if zeroflag is not set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVNE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVNE - Move if not equal (ZF=0)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVNE DEST,SRC<br>
+    <strong>Effects:</strong> If (ZF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if zeroflag is not set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVNG.htm
+++ b/src/help/en/CMOVNG.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVNG.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVNG - Move if not greater (ZF=1 or SF<>OF)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVNGA DEST,SRC<br>
-			<strong>Effects:</strong> If (CF=1 and SF<>OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag is set and signflag and overflowflag are not equal. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVNG.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVNG - Move if not greater (ZF=1 or SF<>OF)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVNGA DEST,SRC<br>
+    <strong>Effects:</strong> If (CF=1 and SF<>OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if carryflag is set and signflag and overflowflag are not equal. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVNGE.htm
+++ b/src/help/en/CMOVNGE.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVNGE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVNGE - Move if not greater or equal (SF<>OF)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVNGE DEST,SRC<br>
-			<strong>Effects:</strong> If (SF<>OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if signflag and overflowflag are not equal. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVNGE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVNGE - Move if not greater or equal (SF<>OF)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVNGE DEST,SRC<br>
+    <strong>Effects:</strong> If (SF<>OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if signflag and overflowflag are not equal. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVNL.htm
+++ b/src/help/en/CMOVNL.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVNL.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVNL - Move if not less (SF=OF)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVNL DEST,SRC<br>
-			<strong>Effects:</strong> If (SF=OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if signflag and overflowflag are equal. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVNL.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVNL - Move if not less (SF=OF)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVNL DEST,SRC<br>
+    <strong>Effects:</strong> If (SF=OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if signflag and overflowflag are equal. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVNLE.htm
+++ b/src/help/en/CMOVNLE.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVNLE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVNLE - Move if not less or equal (ZF=0 and SF=OF)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVNLE DEST,SRC<br>
-			<strong>Effects:</strong> If (ZF=0 and SF=OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if zeroflag is not set and signflag and overflowflag are equal. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVNLE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVNLE - Move if not less or equal (ZF=0 and SF=OF)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVNLE DEST,SRC<br>
+    <strong>Effects:</strong> If (ZF=0 and SF=OF): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if zeroflag is not set and signflag and overflowflag are equal. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVNO.htm
+++ b/src/help/en/CMOVNO.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVNO.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVNO - Move if not overflow (OF=0)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVNO DEST,SRC<br>
-			<strong>Effects:</strong> If (OF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if overflowflag is not set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVNO.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVNO - Move if not overflow (OF=0)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVNO DEST,SRC<br>
+    <strong>Effects:</strong> If (OF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if overflowflag is not set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVNP.htm
+++ b/src/help/en/CMOVNP.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVNP.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVNP - Move if not parity (PF=0)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVNP DEST,SRC<br>
-			<strong>Effects:</strong> If (PF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if parityflag is not set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVNP.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVNP - Move if not parity (PF=0)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVNP DEST,SRC<br>
+    <strong>Effects:</strong> If (PF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if parityflag is not set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVNS.htm
+++ b/src/help/en/CMOVNS.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVNS.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVNS - Move if not sign (SF=0)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVNS DEST,SRC<br>
-			<strong>Effects:</strong> If (SF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if signflag is not set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVNS.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVNS - Move if not sign (SF=0)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVNS DEST,SRC<br>
+    <strong>Effects:</strong> If (SF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if signflag is not set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVNZ.htm
+++ b/src/help/en/CMOVNZ.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVNZ.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVNZ - Move if not zero (ZF=0)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVNZ DEST,SRC<br>
-			<strong>Effects:</strong> If (ZF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if zeroflag is not set. Otherwise the programm continues with the next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVNZ.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVNZ - Move if not zero (ZF=0)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVNZ DEST,SRC<br>
+    <strong>Effects:</strong> If (ZF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if zeroflag is not set. Otherwise the programm continues with the next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVO.htm
+++ b/src/help/en/CMOVO.htm
@@ -1,18 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVO.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVO - Move if overflow (OF=0)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVO DEST,SRC<br>
-			<strong>Effects:</strong> If (OF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if overflowflag is not set. Otherwise the programm continues with the next operation.
-<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVO.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVO - Move if overflow (OF=0)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVO DEST,SRC<br>
+    <strong>Effects:</strong> If (OF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if overflowflag is not set. Otherwise the programm continues with the next operation.
+    <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVP.htm
+++ b/src/help/en/CMOVP.htm
@@ -1,18 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVP.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVP - Move if parity (PF=1)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVP DEST,SRC<br>
-			<strong>Effects:</strong> If (PF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if parityflag is set. Otherwise the programm continues with the next operation.
-<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVP.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVP - Move if parity (PF=1)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVP DEST,SRC<br>
+    <strong>Effects:</strong> If (PF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if parityflag is set. Otherwise the programm continues with the next operation.
+    <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVPE.htm
+++ b/src/help/en/CMOVPE.htm
@@ -1,18 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVPE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVPE - Move if parity even (PF=1)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVPE DEST,SRC<br>
-			<strong>Effects:</strong> If (PF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if parityflag is  set. Otherwise the programm continues with the next operation.
-<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVPE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVPE - Move if parity even (PF=1)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVPE DEST,SRC<br>
+    <strong>Effects:</strong> If (PF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if parityflag is set. Otherwise the programm continues with the next operation.
+    <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVPO.htm
+++ b/src/help/en/CMOVPO.htm
@@ -1,18 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVPO.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVPO - Move if parity odd (PF=0)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVPO DEST,SRC<br>
-			<strong>Effects:</strong> If (CF=0 and ZF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if parityflag is not set. Otherwise the programm continues with the next operation.
-<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVPO.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVPO - Move if parity odd (PF=0)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVPO DEST,SRC<br>
+    <strong>Effects:</strong> If (CF=0 and ZF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if parityflag is not set. Otherwise the programm continues with the next operation.
+    <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVS.htm
+++ b/src/help/en/CMOVS.htm
@@ -1,18 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVS.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVS - Move if sign (SF=1)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVS DEST,SRC<br>
-			<strong>Effects:</strong> If (SF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if signflag is set. Otherwise the programm continues with the next operation.
-<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVS.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVS - Move if sign (SF=1)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVS DEST,SRC<br>
+    <strong>Effects:</strong> If (SF=1): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if signflag is set. Otherwise the programm continues with the next operation.
+    <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMOVZ.htm
+++ b/src/help/en/CMOVZ.htm
@@ -1,18 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMOVZ.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMOVZ - Move if zero (ZF=1)<br>
-			<strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
-			<strong>Usage:</strong> CMOVZ DEST,SRC<br>
-			<strong>Effects:</strong> If (CF=0 and ZF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if zeroflag is set. Otherwise the programm continues with the next operation.
-<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMOVZ.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMOVZ - Move if zero (ZF=1)<br>
+    <strong>Arguments:</strong> DEST: general-purpose register (16 or 32 bit); SRC: general purpose register (16 or 32 bit) or memory location<br>
+    <strong>Usage:</strong> CMOVZ DEST,SRC<br>
+    <strong>Effects:</strong> If (CF=0 and ZF=0): DEST := SRC; Copies the source value (second argument) to the destination (first argument) if zeroflag is set. Otherwise the programm continues with the next operation.
+    <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMP.htm
+++ b/src/help/en/CMP.htm
@@ -1,18 +1,18 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMP.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMP - Compare Two Operands<br>
-			<strong>Arguments:</strong> SRC1: Immediate, Register or memory location; SRC2:  Immediate, Register or memory location<br>
-			<strong>Usage:</strong> CMP SRC1, SRC2<br>
-			<strong>Effects:</strong> :=SRC1-SRC2; Flags are set in the same way as the SUB instruction does, but no result is of the substraction is not saved.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The OF, SF, ZF, AF, CF, and PF flags are set according to the result.
-			<br><strong>Misc:</strong> Usually the next operation would be a Jcc or CMOVcc to perform a operation according to the result of the comparison.
-Only one memory argument is allowed and both arguments have to be of the same size (8, 16 or 32bit)</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMP.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMP - Compare Two Operands<br>
+    <strong>Arguments:</strong> SRC1: Immediate, Register or memory location; SRC2: Immediate, Register or memory location<br>
+    <strong>Usage:</strong> CMP SRC1, SRC2<br>
+    <strong>Effects:</strong> :=SRC1-SRC2; Flags are set in the same way as the SUB instruction does, but no result is of the substraction is not saved.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The OF, SF, ZF, AF, CF, and PF flags are set according to the result.
+    <br><strong>Misc:</strong> Usually the next operation would be a Jcc or CMOVcc to perform a operation according to the result of the comparison.
+    Only one memory argument is allowed and both arguments have to be of the same size (8, 16 or 32bit)
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMPS.htm
+++ b/src/help/en/CMPS.htm
@@ -1,18 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMPS.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMPS - Compare String Operands<br>
-			<strong>Arguments:</strong> DEST, SRC: Memory Locations to be compared<br>
-			<strong>Usage:</strong> CMPS DEST, SRC<br>
-			<strong>Effects:</strong> Compares byte/word/doubleword at address DS:(E)SI with byte/word/doubleword at address
-ES:(E)DI and sets the status flags accordingly<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF, SF, ZF, AF, and PF
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMPS.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMPS - Compare String Operands<br>
+    <strong>Arguments:</strong> DEST, SRC: Memory Locations to be compared<br>
+    <strong>Usage:</strong> CMPS DEST, SRC<br>
+    <strong>Effects:</strong> Compares byte/word/doubleword at address DS:(E)SI with byte/word/doubleword at address
+    ES:(E)DI and sets the status flags accordingly<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF, SF, ZF, AF, and PF
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMPSB.htm
+++ b/src/help/en/CMPSB.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMPSB.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMPSB - Compare String Operands<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> CMPSB<br>
-			<strong>Effects:</strong> CMPSW compares the byte at [DS:SI] or [DS:ESI] with byte at [ES:DI] or [ES:EDI], and sets the flags accordingly. It then increments or decrements (depending on the direction flag: increments if the flag is clear, decrements if it is set) SI and DI (or ESI and EDI).<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF, SF, ZF, AF, and PF
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMPSB.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMPSB - Compare String Operands<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> CMPSB<br>
+    <strong>Effects:</strong> CMPSW compares the byte at [DS:SI] or [DS:ESI] with byte at [ES:DI] or [ES:EDI], and sets the flags accordingly. It then increments or decrements (depending on the direction flag: increments if the flag is clear, decrements if it is set) SI and DI (or ESI and EDI).<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF, SF, ZF, AF, and PF
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMPSD.htm
+++ b/src/help/en/CMPSD.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMPSD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMPSD - Compare String Operands<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> CMPSD<br>
-			<strong>Effects:</strong> CMPSW compares the doubleword at [DS:SI] or [DS:ESI] with the doubleword at [ES:DI] or [ES:EDI], and sets the flags accordingly. It then increments or decrements (depending on the direction flag: increments if the flag is clear, decrements if it is set) SI and DI (or ESI and EDI) by 4.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF, SF, ZF, AF, and PF
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMPSD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMPSD - Compare String Operands<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> CMPSD<br>
+    <strong>Effects:</strong> CMPSW compares the doubleword at [DS:SI] or [DS:ESI] with the doubleword at [ES:DI] or [ES:EDI], and sets the flags accordingly. It then increments or decrements (depending on the direction flag: increments if the flag is clear, decrements if it is set) SI and DI (or ESI and EDI) by 4.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF, SF, ZF, AF, and PF
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMPSW.htm
+++ b/src/help/en/CMPSW.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CMPSW.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CMPSW - Compare String Operands<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> CMPSW<br>
-			<strong>Effects:</strong> CMPSW compares the word at [DS:SI] or [DS:ESI] with the word at [ES:DI] or [ES:EDI], and sets the flags accordingly. It then increments or decrements (depending on the direction flag: increments if the flag is clear, decrements if it is set) SI and DI (or ESI and EDI) by 2.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF, SF, ZF, AF, and PF
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CMPSW.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMPSW - Compare String Operands<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> CMPSW<br>
+    <strong>Effects:</strong> CMPSW compares the word at [DS:SI] or [DS:ESI] with the word at [ES:DI] or [ES:EDI], and sets the flags accordingly. It then increments or decrements (depending on the direction flag: increments if the flag is clear, decrements if it is set) SI and DI (or ESI and EDI) by 2.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF, SF, ZF, AF, and PF
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CMPXCHG.htm
+++ b/src/help/en/CMPXCHG.htm
@@ -1,2 +1,10 @@
 <br>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"><head><title>CMPXCHG.htm</title></head><body><div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;"><strong>Command:</strong> CMPXCHG - Compare and Exchange<br><strong>Arguments:</strong> DEST: general-purpose register or memory location; SRC: general-purpose register<br><strong>Usage:</strong> CMPXCHG DEST, SRC<br><strong>Effects:</strong> if (EAX/AX/AL=DEST) then dest:=src else EAX/AX/AL:=dest; If EAX/AX/AL (according to the size of the arguments) and DEST are equal, SRC is copied to DEST, otherwise DEST is copied to EAX/AX/AL.<br><strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> ZF is set if (EAX/AX/AL=DEST). CF, PF, AF, SF, and OF are set according to the results of the comparison.<br><strong>Misc:</strong> Both arguments have to be of the same size.</div></body></html><br>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head><title>CMPXCHG.htm</title></head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMPXCHG - Compare and Exchange<br><strong>Arguments:</strong> DEST: general-purpose register or memory location; SRC: general-purpose register<br><strong>Usage:</strong> CMPXCHG DEST, SRC<br><strong>Effects:</strong> if (EAX/AX/AL=DEST) then dest:=src else EAX/AX/AL:=dest; If EAX/AX/AL (according to the size of the arguments) and DEST are equal, SRC is copied to DEST, otherwise DEST is copied to EAX/AX/AL.<br><strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> ZF is set if (EAX/AX/AL=DEST). CF, PF, AF, SF, and OF are set according to the results of the comparison.<br><strong>Misc:</strong> Both arguments have to be of the same size.
+</div>
+</body>
+</html><br>

--- a/src/help/en/CMPXCHG8B.htm
+++ b/src/help/en/CMPXCHG8B.htm
@@ -1,2 +1,10 @@
 <br>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"><head><title>CMPXCHG8B.htm</title></head><body><div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;"><strong>Command:</strong> CMPXCHG8B - Compare and Exchange Eight Bytes<br><strong>Arguments:</strong> DEST: memory location<br><strong>Usage:</strong> CMPXCHG8B DEST<br><strong>Effects:</strong> Compares the 64-bit value stored at DEST with the value in EDX:EAX. If they are equal, it sets the zero flag and stores ECX:EBX into the memory area. If they are unequal, it clears the zero flag and stores the memory contents into EDX:EAX.<br><strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> ZF<br><strong>Misc:</strong> See also CMPXCHG</div></body></html><br>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head><title>CMPXCHG8B.htm</title></head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CMPXCHG8B - Compare and Exchange Eight Bytes<br><strong>Arguments:</strong> DEST: memory location<br><strong>Usage:</strong> CMPXCHG8B DEST<br><strong>Effects:</strong> Compares the 64-bit value stored at DEST with the value in EDX:EAX. If they are equal, it sets the zero flag and stores ECX:EBX into the memory area. If they are unequal, it clears the zero flag and stores the memory contents into EDX:EAX.<br><strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> ZF<br><strong>Misc:</strong> See also CMPXCHG
+</div>
+</body>
+</html><br>

--- a/src/help/en/CWD.htm
+++ b/src/help/en/CWD.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CWD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CWD - Sign Extension<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> CWD<br>
-			<strong>Effects:</strong> CWD extends AX into DX:AX by repeating the top bit of AX throughout DX<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CWD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CWD - Sign Extension<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> CWD<br>
+    <strong>Effects:</strong> CWD extends AX into DX:AX by repeating the top bit of AX throughout DX<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/CWDE.htm
+++ b/src/help/en/CWDE.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>CWDE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> CWDE - Sign Extension<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> CWDE<br>
-			<strong>Effects:</strong> CWDE extends AX into EAX by repeating the top bit.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>CWDE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> CWDE - Sign Extension<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> CWDE<br>
+    <strong>Effects:</strong> CWDE extends AX into EAX by repeating the top bit.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/DAA.htm
+++ b/src/help/en/DAA.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>DAA.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> DAA - Decimal Adjustments<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> DAA<br>
-			<strong>Effects:</strong> DAA should be used after a one-byte ADD instruction whose destination was the AL register: by means of examining the value in the AL and also the auxiliary carry flag AF, it determines whether either digit of the addition has overflowed, and adjusts it (and sets the carry and auxiliary-carry flags) if so.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=1 and AF=1 if addition has overflowed
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>DAA.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> DAA - Decimal Adjustments<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> DAA<br>
+    <strong>Effects:</strong> DAA should be used after a one-byte ADD instruction whose destination was the AL register: by means of examining the value in the AL and also the auxiliary carry flag AF, it determines whether either digit of the addition has overflowed, and adjusts it (and sets the carry and auxiliary-carry flags) if so.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=1 and AF=1 if addition has overflowed
+</div>
+</body>
+</html>
 			

--- a/src/help/en/DAS.htm
+++ b/src/help/en/DAS.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>DAS.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> DAS - Decimal Adjustments<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> DAS<br>
-			<strong>Effects:</strong> DAS should be used after a one-byte SUB instruction whose destination was the AL register: by means of examining the value in the AL and also the auxiliary carry flag AF, it determines whether either digit of the addition has overflowed, and adjusts it (and sets the carry and auxiliary-carry flags) if so.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=1 and AF=1 if subtraction has overflowed
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>DAS.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> DAS - Decimal Adjustments<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> DAS<br>
+    <strong>Effects:</strong> DAS should be used after a one-byte SUB instruction whose destination was the AL register: by means of examining the value in the AL and also the auxiliary carry flag AF, it determines whether either digit of the addition has overflowed, and adjusts it (and sets the carry and auxiliary-carry flags) if so.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=1 and AF=1 if subtraction has overflowed
+</div>
+</body>
+</html>
 			

--- a/src/help/en/DB.htm
+++ b/src/help/en/DB.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>DB.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> DB - Pseudo: declare one or more bytes<br>
-			<strong>Arguments:</strong> argx: data to be written as dec (5), hex (0x05), character ('a') or string for more bytes ('abc')<br>
-			<strong>Usage:</strong> DB arg1 , [arg2, arg3,...]<br>
-			<strong>Effects:</strong> Writes arguments to memory.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>DB.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> DB - Pseudo: declare one or more bytes<br>
+    <strong>Arguments:</strong> argx: data to be written as dec (5), hex (0x05), character ('a') or string for more bytes ('abc')<br>
+    <strong>Usage:</strong> DB arg1 , [arg2, arg3,...]<br>
+    <strong>Effects:</strong> Writes arguments to memory.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/DD.htm
+++ b/src/help/en/DD.htm
@@ -1,20 +1,19 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>DD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> DD - Pseudo: declare one or more doublewords<br>
-			<strong>Arguments:</strong> argx: data to be written as dec (5), hex (0x12345678), characters ('abcd'), string for more doublewords ('abcdefg') or floating point constant (1.234567e20)<br>
-			<strong>Usage:</strong> DD arg1 , [arg2, arg3,...]<br>
-			<strong>Effects:</strong> Writes arguments to memory.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> Example:
-dd    0x12345678          ; 0x78 0x56 0x34 0x12 
-dd    1.234567e20         ; floating-point constant 
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>DD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> DD - Pseudo: declare one or more doublewords<br>
+    <strong>Arguments:</strong> argx: data to be written as dec (5), hex (0x12345678), characters ('abcd'), string for more doublewords ('abcdefg') or floating point constant (1.234567e20)<br>
+    <strong>Usage:</strong> DD arg1 , [arg2, arg3,...]<br>
+    <strong>Effects:</strong> Writes arguments to memory.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> Example:
+    dd 0x12345678 ; 0x78 0x56 0x34 0x12
+    dd 1.234567e20 ; floating-point constant
 </div>
-			</body>
-			</html>
+</body>
+</html>
 			

--- a/src/help/en/DEC.htm
+++ b/src/help/en/DEC.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>DEC.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> DEC - Decrement by 1<br>
-			<strong>Arguments:</strong> DEST: general-purpose register or memory location<br>
-			<strong>Usage:</strong> DEC DEST<br>
-			<strong>Effects:</strong> DEST:=DEST-1; Substracts 1 from DEST and does not touch the state of carryflag<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The CF flag is not affected. The OF, SF, ZF, AF, and PF flags are set according to the result.
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>DEC.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> DEC - Decrement by 1<br>
+    <strong>Arguments:</strong> DEST: general-purpose register or memory location<br>
+    <strong>Usage:</strong> DEC DEST<br>
+    <strong>Effects:</strong> DEST:=DEST-1; Substracts 1 from DEST and does not touch the state of carryflag<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The CF flag is not affected. The OF, SF, ZF, AF, and PF flags are set according to the result.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/DIV.htm
+++ b/src/help/en/DIV.htm
@@ -1,20 +1,27 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>DIV.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> DIV - Unsigned Divide<br>
-			<strong>Arguments:</strong> SRC: Register or memory location (8, 16 or 32 Bit)<br>
-			<strong>Usage:</strong> DIV SRC<br>
-			<strong>Effects:</strong> 8Bit SRC: AL:=AX / SRC AH:=Rest
-16Bit SRC: AX:=DX:AX / SRC DX:=Rest
-32Bit SRC: EAX:=EDX:EAX / SRC EDX:=Rest
-Divedes (unsigned) the value in the pair of registers as  your can see above (according to the size of SRC) by SRC. The result of the division is saved in the lower part of the pair, the remainder is saved in the upper part of the pair.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The CF, OF, SF, ZF, AF, and PF flags are undefined.
-			<br><strong>Misc:</strong> Non-integral results are truncated towards 0.</div>
-			</body>
-			</html>
+<head>
+    <title>DIV.htm</title>
+</head>
+
+<body>
+<div style="font-family: Helvetica,Arial,sans-serif; font-size: 11px;">
+    <strong>Command:</strong> DIV (Unsigned Divide)<br>
+
+    <strong>Usage:</strong> DIV SRC<br>
+
+    <strong>Arguments:</strong> SRC: Register or memory location (8, 16 or 32 Bit)<br>
+
+    <strong>Effects:</strong> MUL performs unsigned multiplication.<br>8Bit SRC: AL:=AX / SRC; AH:=Remainder<br>
+    16Bit SRC: AX:=DX:AX / SRC; DX:=Remainder<br>
+    32Bit SRC: EAX:=EDX:EAX / SRC; EDX:=Remainder<br>
+    Divides (unsigned) the value in the pair of registers as your can see above (according to the size of SRC) by SRC. The result of the division is saved in the lower part of the pair, the remainder is saved in the upper part of the pair.<br>
+
+    <strong>Flags to be set:</strong> The CF, OF, SF, ZF, AF, and PF flags are undefined.<br>
+
+    <strong>Misc:</strong> Non-integral results are truncated towards 0.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/DQ.htm
+++ b/src/help/en/DQ.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>DQ.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> DQ - Pseudo: declare one or more double-precision floats<br>
-			<strong>Arguments:</strong> argx: data to be written as double-precision float (1.234567e20)<br>
-			<strong>Usage:</strong> DQ arg1 , [arg2, arg3,...]<br>
-			<strong>Effects:</strong> Writes double-precision floats to memory<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> Example: dq    1.234567e20         ; double-precision float </div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>DQ.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> DQ - Pseudo: declare one or more double-precision floats<br>
+    <strong>Arguments:</strong> argx: data to be written as double-precision float (1.234567e20)<br>
+    <strong>Usage:</strong> DQ arg1 , [arg2, arg3,...]<br>
+    <strong>Effects:</strong> Writes double-precision floats to memory<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> Example: dq 1.234567e20 ; double-precision float
+</div>
+</body>
+</html>
 			

--- a/src/help/en/DW.htm
+++ b/src/help/en/DW.htm
@@ -1,18 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>DW.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> DW - Pseudo: declare one or more words<br>
-			<strong>Arguments:</strong> argx: data to be written as dec (5), hex (0x0235), character ('ab') or string for more bytes ('abcd')<br>
-			<strong>Usage:</strong> DW arg1 , [arg2, arg3,...]<br>
-			<strong>Effects:</strong> Writes words to memory<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> 
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>DW.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> DW - Pseudo: declare one or more words<br>
+    <strong>Arguments:</strong> argx: data to be written as dec (5), hex (0x0235), character ('ab') or string for more bytes ('abcd')<br>
+    <strong>Usage:</strong> DW arg1 , [arg2, arg3,...]<br>
+    <strong>Effects:</strong> Writes words to memory<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong>
 </div>
-			</body>
-			</html>
+</body>
+</html>
 			

--- a/src/help/en/EQU.htm
+++ b/src/help/en/EQU.htm
@@ -1,21 +1,20 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>EQU.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> EQU: Pseudo: define constants for the preprocessor<br>
-			<strong>Arguments:</strong> VALUE: immediate, to be written in dec (135) or hex (0x12345678)<br>
-			<strong>Usage:</strong> constlabel: EQU VALUE<br>
-			<strong>Effects:</strong> Creates an alias for imm with name "constlabel".<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none<br>
-			<strong>Misc:</strong>Must be preceded by a label. 
-			<strong>Example:</strong> <br>
-myValue: EQU 3<br>
-MOV EAX, myValue 
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>EQU.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> EQU: Pseudo: define constants for the preprocessor<br>
+    <strong>Arguments:</strong> VALUE: immediate, to be written in dec (135) or hex (0x12345678)<br>
+    <strong>Usage:</strong> constlabel: EQU VALUE<br>
+    <strong>Effects:</strong> Creates an alias for imm with name "constlabel".<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none<br>
+    <strong>Misc:</strong>Must be preceded by a label.
+    <strong>Example:</strong> <br>
+    myValue: EQU 3<br>
+    MOV EAX, myValue
 </div>
-			</body>
-			</html>
+</body>
+</html>
 			

--- a/src/help/en/FADD.htm
+++ b/src/help/en/FADD.htm
@@ -1,18 +1,18 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>FADD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> FADD - Floating-Point Addition<br>
-			<strong>Arguments:</strong> OP: floating point register, TO: FPU qualifier (see Effects) ST0 optional and fix second argument<br>
-			<strong>Usage:</strong> FADD OP or FADD TO OP or FADD OP, ST0 or FADD ST0 OP<br>
-			<strong>Effects:</strong> FADD, given one operand, adds the operand to ST0 and stores the result back in ST0. If the operand has the TO modifier, the result is stored in the register given rather than in ST0. 
-<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> only FPU flags
-			<br><strong>Misc:</strong> The given two-operand forms are synonyms for the one-operand forms.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>FADD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> FADD - Floating-Point Addition<br>
+    <strong>Arguments:</strong> OP: floating point register, TO: FPU qualifier (see Effects) ST0 optional and fix second argument<br>
+    <strong>Usage:</strong> FADD OP or FADD TO OP or FADD OP, ST0 or FADD ST0 OP<br>
+    <strong>Effects:</strong> FADD, given one operand, adds the operand to ST0 and stores the result back in ST0. If the operand has the TO modifier, the result is stored in the register given rather than in ST0.
+    <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> only FPU flags
+    <br><strong>Misc:</strong> The given two-operand forms are synonyms for the one-operand forms.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/FADDP.htm
+++ b/src/help/en/FADDP.htm
@@ -1,18 +1,18 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>FADDP.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> FADDP - Floating-Point Addition<br>
-			<strong>Arguments:</strong> OP: floating point register, ST0 optional and fix second argument<br>
-			<strong>Usage:</strong> FADDP OP or FADDP OP, ST0<br>
-			<strong>Effects:</strong> Adds the OP to ST0 and stores the result back to OP. Pops the register stack after storing the result. 
-<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> only FPU flags
-			<br><strong>Misc:</strong> The given two-operand forms are synonyms for the one-operand forms.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>FADDP.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> FADDP - Floating-Point Addition<br>
+    <strong>Arguments:</strong> OP: floating point register, ST0 optional and fix second argument<br>
+    <strong>Usage:</strong> FADDP OP or FADDP OP, ST0<br>
+    <strong>Effects:</strong> Adds the OP to ST0 and stores the result back to OP. Pops the register stack after storing the result.
+    <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> only FPU flags
+    <br><strong>Misc:</strong> The given two-operand forms are synonyms for the one-operand forms.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/FIADD.htm
+++ b/src/help/en/FIADD.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>FIADD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> FIADD - Floating-Point/Integer Addition<br>
-			<strong>Arguments:</strong> SRC: memory location for 16/32 bit integer value<br>
-			<strong>Usage:</strong> FIADD SRC<br>
-			<strong>Effects:</strong> Adds SRC to ST0 and stores result back to ST0<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> only FPU flags
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>FIADD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> FIADD - Floating-Point/Integer Addition<br>
+    <strong>Arguments:</strong> SRC: memory location for 16/32 bit integer value<br>
+    <strong>Usage:</strong> FIADD SRC<br>
+    <strong>Effects:</strong> Adds SRC to ST0 and stores result back to ST0<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> only FPU flags
+</div>
+</body>
+</html>
 			

--- a/src/help/en/FILD.htm
+++ b/src/help/en/FILD.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>FILD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> FILD - Integer -> Floating-Point Conversion<br>
-			<strong>Arguments:</strong> SRC memory location of 16/32/64 bit integer<br>
-			<strong>Usage:</strong> FILD SRC<br>
-			<strong>Effects:</strong> Loads SRC, converts it to a real and pushes it to FPU register stack<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> only FPU flags
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>FILD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> FILD - Integer -> Floating-Point Conversion<br>
+    <strong>Arguments:</strong> SRC memory location of 16/32/64 bit integer<br>
+    <strong>Usage:</strong> FILD SRC<br>
+    <strong>Effects:</strong> Loads SRC, converts it to a real and pushes it to FPU register stack<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> only FPU flags
+</div>
+</body>
+</html>
 			

--- a/src/help/en/FIST.htm
+++ b/src/help/en/FIST.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>FIST.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> FIST - Floating-Point -> Integer Conversion<br>
-			<strong>Arguments:</strong> DEST memory location of 16/32 bit integer<br>
-			<strong>Usage:</strong> FIST DEST<br>
-			<strong>Effects:</strong> Converts ST0 to an integer and stores it to DEST<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> only FPU flags
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>FIST.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> FIST - Floating-Point -> Integer Conversion<br>
+    <strong>Arguments:</strong> DEST memory location of 16/32 bit integer<br>
+    <strong>Usage:</strong> FIST DEST<br>
+    <strong>Effects:</strong> Converts ST0 to an integer and stores it to DEST<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> only FPU flags
+</div>
+</body>
+</html>
 			

--- a/src/help/en/FISTP.htm
+++ b/src/help/en/FISTP.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>FISTP.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> FISTP - Floating-Point -> Integer Conversion and POP register stack<br>
-			<strong>Arguments:</strong> DEST memory location of 16/32/64 bit integer<br>
-			<strong>Usage:</strong> FISTP DEST<br>
-			<strong>Effects:</strong> Converts ST0 to an integer, stores it to DEST and pops the register stack afterwards.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> only FPU flags
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>FISTP.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> FISTP - Floating-Point -> Integer Conversion and POP register stack<br>
+    <strong>Arguments:</strong> DEST memory location of 16/32/64 bit integer<br>
+    <strong>Usage:</strong> FISTP DEST<br>
+    <strong>Effects:</strong> Converts ST0 to an integer, stores it to DEST and pops the register stack afterwards.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> only FPU flags
+</div>
+</body>
+</html>
 			

--- a/src/help/en/IDIV.htm
+++ b/src/help/en/IDIV.htm
@@ -1,20 +1,20 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>IDIV.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> IDIV - Signed integer division<br>
-			<strong>Arguments:</strong> SRC: register or memory location<br>
-			<strong>Usage:</strong> IDIV SRC<br>
-			<strong>Effects:</strong> EAX:=EDX:EAX / SRC; EDX:=rest of division
-Signed division of registers (see below) by src<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> If SRC is 8 bit AX is divided, result is stored in AL and rest is stored in AH
-If SRC is 16 bit DX:AX is divided, result is stored in AX and rest is stored in DX
-If SRC is 32 bit EDX:EAX is divided, result is stored in EAX and rest is stored in EDX</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>IDIV.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> IDIV - Signed integer division<br>
+    <strong>Arguments:</strong> SRC: register or memory location<br>
+    <strong>Usage:</strong> IDIV SRC<br>
+    <strong>Effects:</strong> EAX:=EDX:EAX / SRC; EDX:=rest of division
+    Signed division of registers (see below) by src<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> If SRC is 8 bit AX is divided, result is stored in AL and rest is stored in AH
+    If SRC is 16 bit DX:AX is divided, result is stored in AX and rest is stored in DX
+    If SRC is 32 bit EDX:EAX is divided, result is stored in EAX and rest is stored in EDX
+</div>
+</body>
+</html>
 			

--- a/src/help/en/IMUL.htm
+++ b/src/help/en/IMUL.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>IMUL.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> IMUL- Signed integer multiplication<br>
-			<strong>Arguments:</strong> DEST and SRC: register , IMMED: immediate (if all three are given IMMED must be 8bit)<br>
-			<strong>Usage:</strong> IMUL [DEST,] SRC [,IMMED]<br>
-			<strong>Effects:</strong> Signed multiplication of register (or possibly of dest) by src (and possibly an immediate factor).<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF and OF
-			<br><strong>Misc:</strong> Operands in brackets are optional. If SRC is 8bit it's multiplied by AL and the result stored in AX. If src is 16bit, AX is multiplied and the result is stored in DX:AX. If SRC is 32bit, EAX is multiplied an the result is stored in EDX:EAX.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>IMUL.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> IMUL- Signed integer multiplication<br>
+    <strong>Arguments:</strong> DEST and SRC: register , IMMED: immediate (if all three are given IMMED must be 8bit)<br>
+    <strong>Usage:</strong> IMUL [DEST,] SRC [,IMMED]<br>
+    <strong>Effects:</strong> Signed multiplication of register (or possibly of dest) by src (and possibly an immediate factor).<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF and OF
+    <br><strong>Misc:</strong> Operands in brackets are optional. If SRC is 8bit it's multiplied by AL and the result stored in AX. If src is 16bit, AX is multiplied and the result is stored in DX:AX. If SRC is 32bit, EAX is multiplied an the result is stored in EDX:EAX.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/INC.htm
+++ b/src/help/en/INC.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>INC.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> INC-Increment by 1<br>
-			<strong>Arguments:</strong> DEST: register or memory location<br>
-			<strong>Usage:</strong> INC DEST<br>
-			<strong>Effects:</strong> DEST = DEST + 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The OF, SF, ZF, AF, and PF flags are set according to the result.
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>INC.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> INC-Increment by 1<br>
+    <strong>Arguments:</strong> DEST: register or memory location<br>
+    <strong>Usage:</strong> INC DEST<br>
+    <strong>Effects:</strong> DEST = DEST + 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The OF, SF, ZF, AF, and PF flags are set according to the result.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/INT.htm
+++ b/src/help/en/INT.htm
@@ -1,26 +1,25 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>INT.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> Sends a software interrupt<br>
+    <strong>Arguments:</strong> TYPE: An immediate number from 0-255 defining the type of interrupt<br>
+    <strong>Usage:</strong> INT TYPE<br>
+    <strong>Effects:</strong> INT sends an interrupt.
 
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>INT.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> Sends a software interrupt<br>
-			<strong>Arguments:</strong> TYPE: An immediate number from 0-255 defining the type of interrupt<br>
-			<strong>Usage:</strong> INT TYPE<br>
-			<strong>Effects:</strong> INT sends an interrupt.
-			
-Interrupts are usually handled by the Operating System.
+    Interrupts are usually handled by the Operating System.
 
-Currently Jasmin implements a small part of the DOS-Interrupt 0x21, which may be used to interactively read a string 
-supplied by the user into memory. AH has to be set to 0x0A and a memory location must be provided in DX. The first byte there 
-must be set to determine the maximum buffer length. The next byte will be set by the interrupt handler, indicating how many bytes have been read. 
-After that a string of bytes of that length follows. Finally it is terminated by a NULL-string.
+    Currently Jasmin implements a small part of the DOS-Interrupt 0x21, which may be used to interactively read a string
+    supplied by the user into memory. AH has to be set to 0x0A and a memory location must be provided in DX. The first byte there
+    must be set to determine the maximum buffer length. The next byte will be set by the interrupt handler, indicating how many bytes have been read.
+    After that a string of bytes of that length follows. Finally it is terminated by a NULL-string.
 
-<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+    <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JA.htm
+++ b/src/help/en/JA.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JA.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JA-Jump if Above (CF=0 and ZF=0)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JA label<br>
-			<strong>Effects:</strong> If both carry and zero flags are clear transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JNBE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JA.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JA-Jump if Above (CF=0 and ZF=0)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JA label<br>
+    <strong>Effects:</strong> If both carry and zero flags are clear transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JNBE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JAE.htm
+++ b/src/help/en/JAE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JAE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JAE-Jump if above or equal (CF=0)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JAE label<br>
-			<strong>Effects:</strong> If carry flag is clear transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JNB and JNC </div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JAE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JAE-Jump if above or equal (CF=0)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JAE label<br>
+    <strong>Effects:</strong> If carry flag is clear transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JNB and JNC
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JASMINSLEEP.htm
+++ b/src/help/en/JASMINSLEEP.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JASMINSLEEP.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JASMINSLEEP - Let Jasmin pause for a given number of milliseconds<br>
-			<strong>Arguments:</strong> An immediate, or a register, or a memory location specifying how long to pause, in milliseconds.<br>
-			<strong>Usage:</strong> JASMINSLEEP number_of_msecs<br>
-			<strong>Effects:</strong> WARNING: THIS COMMAND IS NOT PART OF A REAL PROCESSOR'S INSTRUCTION SET! Please be aware that any program using it will only run inside Jasmin. <br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JASMINSLEEP.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JASMINSLEEP - Let Jasmin pause for a given number of milliseconds<br>
+    <strong>Arguments:</strong> An immediate, or a register, or a memory location specifying how long to pause, in milliseconds.<br>
+    <strong>Usage:</strong> JASMINSLEEP number_of_msecs<br>
+    <strong>Effects:</strong> WARNING: THIS COMMAND IS NOT PART OF A REAL PROCESSOR'S INSTRUCTION SET! Please be aware that any program using it will only run inside Jasmin. <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JB.htm
+++ b/src/help/en/JB.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JB.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JB-Jump if not above or equal (CF=1)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JB label<br>
-			<strong>Effects:</strong> If carry flag is clear transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JNAE and JC</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JB.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JB-Jump if not above or equal (CF=1)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JB label<br>
+    <strong>Effects:</strong> If carry flag is clear transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JNAE and JC
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JBE.htm
+++ b/src/help/en/JBE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JBE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JBE - Jump if below or equal (CF=1 or ZF=1)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JBE label<br>
-			<strong>Effects:</strong> If carry flag is set and zeroflag is set transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JNA</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JBE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JBE - Jump if below or equal (CF=1 or ZF=1)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JBE label<br>
+    <strong>Effects:</strong> If carry flag is set and zeroflag is set transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JNA
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JC.htm
+++ b/src/help/en/JC.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JC.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JC-Jump if Carry (CF=1)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JC label<br>
-			<strong>Effects:</strong> If carry flag is set transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JB and JNAE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JC.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JC-Jump if Carry (CF=1)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JC label<br>
+    <strong>Effects:</strong> If carry flag is set transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JB and JNAE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JCXZ.htm
+++ b/src/help/en/JCXZ.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JCXZ.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JCXZ-Jump if CX Zero<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JCXZ label<br>
-			<strong>Effects:</strong> If the resgister CX is zero transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as JECXZ</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JCXZ.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JCXZ-Jump if CX Zero<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JCXZ label<br>
+    <strong>Effects:</strong> If the resgister CX is zero transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as JECXZ
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JE.htm
+++ b/src/help/en/JE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JE - Jump if equal (ZF=1)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JE label<br>
-			<strong>Effects:</strong> If zeroflag is set transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> Same as JZ</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JE - Jump if equal (ZF=1)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JE label<br>
+    <strong>Effects:</strong> If zeroflag is set transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> Same as JZ
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JECXZ.htm
+++ b/src/help/en/JECXZ.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JECXZ.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JECXZ-Jump if CX Zero<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JECXZ label<br>
-			<strong>Effects:</strong> If the resgister CX is zero transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as JCXZ</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JECXZ.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JECXZ-Jump if CX Zero<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JECXZ label<br>
+    <strong>Effects:</strong> If the resgister CX is zero transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as JCXZ
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JG.htm
+++ b/src/help/en/JG.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JG.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JG-Jump if Greater (signed) (ZF=0 and SF=OF)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JG label<br>
-			<strong>Effects:</strong> If zero flag is clear and overflow and Signed flags are equal transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as JNLE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JG.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JG-Jump if Greater (signed) (ZF=0 and SF=OF)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JG label<br>
+    <strong>Effects:</strong> If zero flag is clear and overflow and Signed flags are equal transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as JNLE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JGE.htm
+++ b/src/help/en/JGE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JGE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JGE-Jump if greater or equal (signed) (SF=OF)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JGE label<br>
-			<strong>Effects:</strong> If signed and overflow flags equal (both set or both clear) transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as JNL</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JGE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JGE-Jump if greater or equal (signed) (SF=OF)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JGE label<br>
+    <strong>Effects:</strong> If signed and overflow flags equal (both set or both clear) transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as JNL
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JL.htm
+++ b/src/help/en/JL.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JL.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JL-Jump if less (signed) (SF!=OF)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JL label<br>
-			<strong>Effects:</strong> If signed and overflow flags differ (one set, the other clear) transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as JNGE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JL.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JL-Jump if less (signed) (SF!=OF)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JL label<br>
+    <strong>Effects:</strong> If signed and overflow flags differ (one set, the other clear) transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as JNGE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JLE.htm
+++ b/src/help/en/JLE.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JLE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JLE - Jump if less or equal (ZF=1 or SF!=OF)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JLE label<br>
-			<strong>Effects:</strong> If zeroflag is set and signed and overflow flags differ (one set, the other clear) transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JLE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JLE - Jump if less or equal (ZF=1 or SF!=OF)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JLE label<br>
+    <strong>Effects:</strong> If zeroflag is set and signed and overflow flags differ (one set, the other clear) transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JMP.htm
+++ b/src/help/en/JMP.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JMP.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JMP-Unconditional Jump<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JMP label<br>
-			<strong>Effects:</strong> Transfer control to label without recording return information.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> compare: CALL</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JMP.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JMP-Unconditional Jump<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JMP label<br>
+    <strong>Effects:</strong> Transfer control to label without recording return information.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> compare: CALL
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JNA.htm
+++ b/src/help/en/JNA.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JNA.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JNA - Jump if not above (CF=1 or ZF=1)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JNA label<br>
-			<strong>Effects:</strong> If carry flag is set and zeroflag is set transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> Same as JBE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JNA.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JNA - Jump if not above (CF=1 or ZF=1)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JNA label<br>
+    <strong>Effects:</strong> If carry flag is set and zeroflag is set transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> Same as JBE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JNAE.htm
+++ b/src/help/en/JNAE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JNAE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JNAE-Jump if not above or equal (CF=1)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JNAE label<br>
-			<strong>Effects:</strong> If carry flag is set transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JB and JC</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JNAE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JNAE-Jump if not above or equal (CF=1)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JNAE label<br>
+    <strong>Effects:</strong> If carry flag is set transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JB and JC
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JNB.htm
+++ b/src/help/en/JNB.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JNB.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JNB-Jump if not below (CF=0)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JNB label<br>
-			<strong>Effects:</strong> If carry flag is clear transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JNC and JAE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JNB.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JNB-Jump if not below (CF=0)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JNB label<br>
+    <strong>Effects:</strong> If carry flag is clear transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JNC and JAE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JNBE.htm
+++ b/src/help/en/JNBE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JNBE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JNBE-Jump if not below or equal (CF=0 and ZF=0)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JNBE label<br>
-			<strong>Effects:</strong> If both carry and zero flags are clear transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JA</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JNBE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JNBE-Jump if not below or equal (CF=0 and ZF=0)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JNBE label<br>
+    <strong>Effects:</strong> If both carry and zero flags are clear transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JA
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JNC.htm
+++ b/src/help/en/JNC.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JNC.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JNC-Jump if not Carry (CF=0)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JNC label<br>
-			<strong>Effects:</strong> If carry flag is clear transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JNC.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JNC-Jump if not Carry (CF=0)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JNC label<br>
+    <strong>Effects:</strong> If carry flag is clear transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JNE.htm
+++ b/src/help/en/JNE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JNE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JNE-Jump if Not Equal (ZF=0)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JNE label<br>
-			<strong>Effects:</strong> If ZF is clear transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JNZ</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JNE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JNE-Jump if Not Equal (ZF=0)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JNE label<br>
+    <strong>Effects:</strong> If ZF is clear transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JNZ
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JNG.htm
+++ b/src/help/en/JNG.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JNG.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JNG-Jump if not greater (signed) (ZF=1 or SF != OF)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JNG label<br>
-			<strong>Effects:</strong> If zero flag is set or signed and overflow flags differ (one set, the other clear) transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JNG.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JNG-Jump if not greater (signed) (ZF=1 or SF != OF)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JNG label<br>
+    <strong>Effects:</strong> If zero flag is set or signed and overflow flags differ (one set, the other clear) transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JNGE.htm
+++ b/src/help/en/JNGE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JNGE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JNGE-Jump if not greater or equal (signed) (SF!=OF)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JNGE label<br>
-			<strong>Effects:</strong> If signed and overflow flags differ (one set, the other clear) transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JL</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JNGE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JNGE-Jump if not greater or equal (signed) (SF!=OF)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JNGE label<br>
+    <strong>Effects:</strong> If signed and overflow flags differ (one set, the other clear) transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JL
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JNL.htm
+++ b/src/help/en/JNL.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JNL.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JNL-Jump if not Less (signed) (SF=OF)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JNL label<br>
-			<strong>Effects:</strong> If signed and overflow flags equal (both set or both clear) transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JGE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JNL.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JNL-Jump if not Less (signed) (SF=OF)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JNL label<br>
+    <strong>Effects:</strong> If signed and overflow flags equal (both set or both clear) transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JGE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JNLE.htm
+++ b/src/help/en/JNLE.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JNLE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JNLE-Jump if not Less or Equal (signed) (ZF=0 and SF=OF)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JNLE label<br>
-			<strong>Effects:</strong> If zero and overflow flags are clear transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JNLE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JNLE-Jump if not Less or Equal (signed) (ZF=0 and SF=OF)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JNLE label<br>
+    <strong>Effects:</strong> If zero and overflow flags are clear transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JNO.htm
+++ b/src/help/en/JNO.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JNO.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JNO-Jump if not Overflow (OF=0)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JNS label<br>
-			<strong>Effects:</strong> If OF is clear transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JNO.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JNO-Jump if not Overflow (OF=0)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JNS label<br>
+    <strong>Effects:</strong> If OF is clear transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JNP.htm
+++ b/src/help/en/JNP.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JNP.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JNP-Jump if Parity Odd (PF=0)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JNP label<br>
-			<strong>Effects:</strong> If PF is clear transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JPO</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JNP.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JNP-Jump if Parity Odd (PF=0)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JNP label<br>
+    <strong>Effects:</strong> If PF is clear transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JPO
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JNS.htm
+++ b/src/help/en/JNS.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JNS.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JNS-Jump if Not Signed (SF=0)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JNS label<br>
-			<strong>Effects:</strong> If SF is clear transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JNS.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JNS-Jump if Not Signed (SF=0)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JNS label<br>
+    <strong>Effects:</strong> If SF is clear transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JNZ.htm
+++ b/src/help/en/JNZ.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JNZ.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JNZ-Jump if Not Zero (ZF=0)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JNZ label<br>
-			<strong>Effects:</strong> If ZF is clear transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JNE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JNZ.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JNZ-Jump if Not Zero (ZF=0)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JNZ label<br>
+    <strong>Effects:</strong> If ZF is clear transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JNE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JO.htm
+++ b/src/help/en/JO.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JO.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JO-Jump if Overflow (OF=1)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JNS label<br>
-			<strong>Effects:</strong> If OF is set transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JO.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JO-Jump if Overflow (OF=1)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JNS label<br>
+    <strong>Effects:</strong> If OF is set transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JP.htm
+++ b/src/help/en/JP.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JP.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JP-Jump if Parity Even (PF=1)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JP label<br>
-			<strong>Effects:</strong> If PF is set transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JPE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JP.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JP-Jump if Parity Even (PF=1)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JP label<br>
+    <strong>Effects:</strong> If PF is set transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JPE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JPE.htm
+++ b/src/help/en/JPE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JPE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JPE-Jump if Parity Even (PF=1)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JPE label<br>
-			<strong>Effects:</strong> If PF is set transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JP</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JPE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JPE-Jump if Parity Even (PF=1)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JPE label<br>
+    <strong>Effects:</strong> If PF is set transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JP
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JPO.htm
+++ b/src/help/en/JPO.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JPO.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JPO-Jump if Parity Odd (PF=0)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JPO label<br>
-			<strong>Effects:</strong> If PF is clear transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			<br><strong>Misc:</strong> same as JO</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JPO.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JPO-Jump if Parity Odd (PF=0)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JPO label<br>
+    <strong>Effects:</strong> If PF is clear transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+    <br><strong>Misc:</strong> same as JO
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JS.htm
+++ b/src/help/en/JS.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JS.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JS-Jump if Signed (SF=1)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JS label<br>
-			<strong>Effects:</strong> If SF is set, transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JS.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JS-Jump if Signed (SF=1)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JS label<br>
+    <strong>Effects:</strong> If SF is set, transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+</div>
+</body>
+</html>
 			

--- a/src/help/en/JZ.htm
+++ b/src/help/en/JZ.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>JZ.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> JZ-Jump if Zero (ZF=1)<br>
-			<strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
-			<strong>Usage:</strong> JZ label<br>
-			<strong>Effects:</strong> If ZF is set, transfer control to label without recording return information, else continue with next operation.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>JZ.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> JZ-Jump if Zero (ZF=1)<br>
+    <strong>Arguments:</strong> label: label pointing to the destination in the instruction stream<br>
+    <strong>Usage:</strong> JZ label<br>
+    <strong>Effects:</strong> If ZF is set, transfer control to label without recording return information, else continue with next operation.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> None
+</div>
+</body>
+</html>
 			

--- a/src/help/en/LAHF.htm
+++ b/src/help/en/LAHF.htm
@@ -1,18 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>LAHF.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> LAHF - Load Status Flags into AH Register<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> LAHF<br>
-			<strong>Effects:</strong> AH <- EFLAGS(SF:ZF:0:AF:0:PF:1:CF)
-Moves status flags to the AH register<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none (EFLAGS register is not changed only copied)
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>LAHF.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> LAHF - Load Status Flags into AH Register<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> LAHF<br>
+    <strong>Effects:</strong> AH <- EFLAGS(SF:ZF:0:AF:0:PF:1:CF)
+    Moves status flags to the AH register<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none (EFLAGS register is not changed only copied)
+</div>
+</body>
+</html>
 			

--- a/src/help/en/LEA.htm
+++ b/src/help/en/LEA.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>LEA.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> LEA - Load Effective Address<br>
-			<strong>Arguments:</strong> dest: 16 or 32 bit general purpose register, src: memory location<br>
-			<strong>Usage:</strong> LEA dest, src<br>
-			<strong>Effects:</strong> Stores the effective address of the second argument to the register defined by the first argument<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> Normally the memory location would use some addressing calculation</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>LEA.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> LEA - Load Effective Address<br>
+    <strong>Arguments:</strong> dest: 16 or 32 bit general purpose register, src: memory location<br>
+    <strong>Usage:</strong> LEA dest, src<br>
+    <strong>Effects:</strong> Stores the effective address of the second argument to the register defined by the first argument<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> Normally the memory location would use some addressing calculation
+</div>
+</body>
+</html>
 			

--- a/src/help/en/LODS.htm
+++ b/src/help/en/LODS.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>LODS.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> LODS - Load from String<br>
-			<strong>Arguments:</strong> src: memory location<br>
-			<strong>Usage:</strong> LODS src<br>
-			<strong>Effects:</strong> Loads a byte/doubleword from [DS:SI] or [DS:ESI] into AL/AX/EAX and increments or decrements SI/ESI (depending on the direction flag, decrements if DF is set)<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>LODS.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> LODS - Load from String<br>
+    <strong>Arguments:</strong> src: memory location<br>
+    <strong>Usage:</strong> LODS src<br>
+    <strong>Effects:</strong> Loads a byte/doubleword from [DS:SI] or [DS:ESI] into AL/AX/EAX and increments or decrements SI/ESI (depending on the direction flag, decrements if DF is set)<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/LODSB.htm
+++ b/src/help/en/LODSB.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>LODSB.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> LODSB - Load from String<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> LODSB<br>
-			<strong>Effects:</strong> Loads a byte from [DS:SI] or [DS:ESI] into AL and increments or decrements SI/ESI (depending on the direction flag, decrements if DF is set)<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> The register used is SI if the address size is 16 bits, and ESI if it is 32 bits. If you need to use an address size not equal to the current BITS setting, you can use an explicit a16 or a32 prefix.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>LODSB.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> LODSB - Load from String<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> LODSB<br>
+    <strong>Effects:</strong> Loads a byte from [DS:SI] or [DS:ESI] into AL and increments or decrements SI/ESI (depending on the direction flag, decrements if DF is set)<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> The register used is SI if the address size is 16 bits, and ESI if it is 32 bits. If you need to use an address size not equal to the current BITS setting, you can use an explicit a16 or a32 prefix.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/LODSD.htm
+++ b/src/help/en/LODSD.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>LODSD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> LODSD - Load from String<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> LODSD<br>
-			<strong>Effects:</strong> Loads a doubleword from [DS:SI] or [DS:ESI] into EAX and increments or decrements SI/ESI (depending on the direction flag, decrements if DF is set) by 4<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> The register used is SI if the address size is 16 bits, and ESI if it is 32 bits. If you need to use an address size not equal to the current BITS setting, you can use an explicit a16 or a32 prefix.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>LODSD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> LODSD - Load from String<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> LODSD<br>
+    <strong>Effects:</strong> Loads a doubleword from [DS:SI] or [DS:ESI] into EAX and increments or decrements SI/ESI (depending on the direction flag, decrements if DF is set) by 4<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> The register used is SI if the address size is 16 bits, and ESI if it is 32 bits. If you need to use an address size not equal to the current BITS setting, you can use an explicit a16 or a32 prefix.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/LODSW.htm
+++ b/src/help/en/LODSW.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>LODSW.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> LODSW - Load from String<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> LODSW<br>
-			<strong>Effects:</strong> Loads a word from [DS:SI] or [DS:ESI] into AX and increments or decrements SI/ESI by 2 (depending on the direction flag, decrements if DF is set)<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> The register used is SI if the address size is 16 bits, and ESI if it is 32 bits. If you need to use an address size not equal to the current BITS setting, you can use an explicit a16 or a32 prefix.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>LODSW.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> LODSW - Load from String<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> LODSW<br>
+    <strong>Effects:</strong> Loads a word from [DS:SI] or [DS:ESI] into AX and increments or decrements SI/ESI by 2 (depending on the direction flag, decrements if DF is set)<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> The register used is SI if the address size is 16 bits, and ESI if it is 32 bits. If you need to use an address size not equal to the current BITS setting, you can use an explicit a16 or a32 prefix.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/LOOP.htm
+++ b/src/help/en/LOOP.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>LOOP.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> LOOP-Loop while CX is not zero<br>
-			<strong>Arguments:</strong> label: label that points to the beginning of the iteration<br>
-			<strong>Usage:</strong> LOOP label<br>
-			<strong>Effects:</strong> Decrements CX (not modifying any flags) and jumps to label if CX is not zero<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> Create a loop of N iterations by copying N to CX (MOV CX,N), adding a label to the beginning of the block of operations to be repeated and a LOOP statement to its end.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>LOOP.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> LOOP-Loop while CX is not zero<br>
+    <strong>Arguments:</strong> label: label that points to the beginning of the iteration<br>
+    <strong>Usage:</strong> LOOP label<br>
+    <strong>Effects:</strong> Decrements CX (not modifying any flags) and jumps to label if CX is not zero<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> Create a loop of N iterations by copying N to CX (MOV CX,N), adding a label to the beginning of the block of operations to be repeated and a LOOP statement to its end.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/LOOPE.htm
+++ b/src/help/en/LOOPE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>LOOPE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> LOOPE-Loop while equal<br>
-			<strong>Arguments:</strong> label: label that points to the beginning of the iteration<br>
-			<strong>Usage:</strong> LOOPE label<br>
-			<strong>Effects:</strong> Decrements CX (not modifying any flags) and jumps to label if CX is not zero and zero flag is set<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as LOOPZ</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>LOOPE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> LOOPE-Loop while equal<br>
+    <strong>Arguments:</strong> label: label that points to the beginning of the iteration<br>
+    <strong>Usage:</strong> LOOPE label<br>
+    <strong>Effects:</strong> Decrements CX (not modifying any flags) and jumps to label if CX is not zero and zero flag is set<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as LOOPZ
+</div>
+</body>
+</html>
 			

--- a/src/help/en/LOOPNE.htm
+++ b/src/help/en/LOOPNE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>LOOPNE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> LOOPNE-Loop while not equal<br>
-			<strong>Arguments:</strong> label: label that points to the beginning of the iteration<br>
-			<strong>Usage:</strong> LOOPNE label<br>
-			<strong>Effects:</strong> Decrements CX (not modifying any flags) and jumps to label if CX is not zero and zero flag is clear<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as LOOPNZ</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>LOOPNE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> LOOPNE-Loop while not equal<br>
+    <strong>Arguments:</strong> label: label that points to the beginning of the iteration<br>
+    <strong>Usage:</strong> LOOPNE label<br>
+    <strong>Effects:</strong> Decrements CX (not modifying any flags) and jumps to label if CX is not zero and zero flag is clear<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as LOOPNZ
+</div>
+</body>
+</html>
 			

--- a/src/help/en/LOOPNZ.htm
+++ b/src/help/en/LOOPNZ.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>LOOPNZ.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> LOOPNZ-Loop while not zero<br>
-			<strong>Arguments:</strong> label: label that points to the beginning of the iteration<br>
-			<strong>Usage:</strong> LOOPNZ label<br>
-			<strong>Effects:</strong> Decrements CX (not modifying any flags) and jumps to label if CX is not zero and zero flag is clear<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as LOOPNE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>LOOPNZ.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> LOOPNZ-Loop while not zero<br>
+    <strong>Arguments:</strong> label: label that points to the beginning of the iteration<br>
+    <strong>Usage:</strong> LOOPNZ label<br>
+    <strong>Effects:</strong> Decrements CX (not modifying any flags) and jumps to label if CX is not zero and zero flag is clear<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as LOOPNE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/LOOPZ.htm
+++ b/src/help/en/LOOPZ.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>LOOPZ.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> LOOPZ-Loop while zero<br>
-			<strong>Arguments:</strong> label: label that points to the beginning of the iteration<br>
-			<strong>Usage:</strong> LOOPE label<br>
-			<strong>Effects:</strong> Decrements CX (not modifying any flags) and jumps to label if CX is not zero and zero flag is set<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as LOOPE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>LOOPZ.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> LOOPZ-Loop while zero<br>
+    <strong>Arguments:</strong> label: label that points to the beginning of the iteration<br>
+    <strong>Usage:</strong> LOOPE label<br>
+    <strong>Effects:</strong> Decrements CX (not modifying any flags) and jumps to label if CX is not zero and zero flag is set<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as LOOPE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/MOV.htm
+++ b/src/help/en/MOV.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>MOV.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> MOV-Move<br>
-			<strong>Arguments:</strong> DEST: general-purpose register, segment register or memory location; SRC: immediate value, general-purpose register, segment register or memory location<br>
-			<strong>Usage:</strong> MOV DEST,SRC<br>
-			<strong>Effects:</strong> DEST := SRC; Copies the source value (second argument) to the destination (first argument).<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> Both arguments must be the same size (byte, word or doubleword). Move cannot be used to load the CS register, use JMP, CALL or RET instead.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>MOV.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> MOV-Move<br>
+    <strong>Arguments:</strong> DEST: general-purpose register, segment register or memory location; SRC: immediate value, general-purpose register, segment register or memory location<br>
+    <strong>Usage:</strong> MOV DEST,SRC<br>
+    <strong>Effects:</strong> DEST := SRC; Copies the source value (second argument) to the destination (first argument).<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> Both arguments must be the same size (byte, word or doubleword). Move cannot be used to load the CS register, use JMP, CALL or RET instead.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/MOVS.htm
+++ b/src/help/en/MOVS.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>MOVS.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> MOVS - Move Data from String to String<br>
-			<strong>Arguments:</strong> DEST, SRC: both memory operands of the same size with address-size-attribute<br>
-			<strong>Usage:</strong> MOVS DEST, SRC<br>
-			<strong>Effects:</strong> Copies the byte/word/doubleword (depending of the size of the parameters) at [DS:SI] or [DS:ESI] to [ES:DI] or [ES:EDI]. It then increments or decrements (depending on the direction flag: increments if the flag is clear, decrements if it is set) SI and DI (or ESI and EDI).<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>MOVS.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> MOVS - Move Data from String to String<br>
+    <strong>Arguments:</strong> DEST, SRC: both memory operands of the same size with address-size-attribute<br>
+    <strong>Usage:</strong> MOVS DEST, SRC<br>
+    <strong>Effects:</strong> Copies the byte/word/doubleword (depending of the size of the parameters) at [DS:SI] or [DS:ESI] to [ES:DI] or [ES:EDI]. It then increments or decrements (depending on the direction flag: increments if the flag is clear, decrements if it is set) SI and DI (or ESI and EDI).<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/MOVSB.htm
+++ b/src/help/en/MOVSB.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>MOVSB.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> MOVSB - Move Byte from String to String<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> MOVSB<br>
-			<strong>Effects:</strong> Copies the byte at [DS:SI] or [DS:ESI] to [ES:DI] or [ES:EDI]. It then increments or decrements (depending on the direction flag: increments if the flag is clear, decrements if it is set) SI and DI (or ESI and EDI).<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>MOVSB.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> MOVSB - Move Byte from String to String<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> MOVSB<br>
+    <strong>Effects:</strong> Copies the byte at [DS:SI] or [DS:ESI] to [ES:DI] or [ES:EDI]. It then increments or decrements (depending on the direction flag: increments if the flag is clear, decrements if it is set) SI and DI (or ESI and EDI).<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/MOVSD.htm
+++ b/src/help/en/MOVSD.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>MOVSD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> MOVSD - Move Doubleword from String to String<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> MOVSD<br>
-			<strong>Effects:</strong> Copies the doubleword at [DS:SI] or [DS:ESI] to [ES:DI] or [ES:EDI]. It then increments or decrements (depending on the direction flag: increments if the flag is clear, decrements if it is set) SI and DI (or ESI and EDI) by 4.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>MOVSD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> MOVSD - Move Doubleword from String to String<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> MOVSD<br>
+    <strong>Effects:</strong> Copies the doubleword at [DS:SI] or [DS:ESI] to [ES:DI] or [ES:EDI]. It then increments or decrements (depending on the direction flag: increments if the flag is clear, decrements if it is set) SI and DI (or ESI and EDI) by 4.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/MOVSW.htm
+++ b/src/help/en/MOVSW.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>MOVSW.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> MOVSW - Move Word from String to String<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> MOVSW<br>
-			<strong>Effects:</strong> Copies the word at [DS:SI] or [DS:ESI] to [ES:DI] or [ES:EDI]. It then increments or decrements (depending on the direction flag: increments if the flag is clear, decrements if it is set) SI and DI (or ESI and EDI) by 2.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>MOVSW.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> MOVSW - Move Word from String to String<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> MOVSW<br>
+    <strong>Effects:</strong> Copies the word at [DS:SI] or [DS:ESI] to [ES:DI] or [ES:EDI]. It then increments or decrements (depending on the direction flag: increments if the flag is clear, decrements if it is set) SI and DI (or ESI and EDI) by 2.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/MOVSX.htm
+++ b/src/help/en/MOVSX.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>MOVSX.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> MOVSX - Move Data with Sign Extend<br>
-			<strong>Arguments:</strong> DEST: 16 or 32 bit register, SRC: 8/16/32 bit register or memory location<br>
-			<strong>Usage:</strong> MOVSX DEST, SRC<br>
-			<strong>Effects:</strong> Sign-extends SRC operand to the length of the DEST operand, and copies the result into DEST operand. <br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> DEST has to be bigger than SRC</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>MOVSX.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> MOVSX - Move Data with Sign Extend<br>
+    <strong>Arguments:</strong> DEST: 16 or 32 bit register, SRC: 8/16/32 bit register or memory location<br>
+    <strong>Usage:</strong> MOVSX DEST, SRC<br>
+    <strong>Effects:</strong> Sign-extends SRC operand to the length of the DEST operand, and copies the result into DEST operand. <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> DEST has to be bigger than SRC
+</div>
+</body>
+</html>
 			

--- a/src/help/en/MOVZX.htm
+++ b/src/help/en/MOVZX.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>MOVZX.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> MOVZX - Move Data with Zero Extend<br>
-			<strong>Arguments:</strong> DEST: 16 or 32 bit register, SRC: 8/16/32 bit register or memory location<br>
-			<strong>Usage:</strong> MOVZX DEST, SRC<br>
-			<strong>Effects:</strong> Zero-extends SRC operand to the length of the DEST operand, and copies the result into DEST operand. <br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> DEST has to be bigger than SRC</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>MOVZX.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> MOVZX - Move Data with Zero Extend<br>
+    <strong>Arguments:</strong> DEST: 16 or 32 bit register, SRC: 8/16/32 bit register or memory location<br>
+    <strong>Usage:</strong> MOVZX DEST, SRC<br>
+    <strong>Effects:</strong> Zero-extends SRC operand to the length of the DEST operand, and copies the result into DEST operand. <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> DEST has to be bigger than SRC
+</div>
+</body>
+</html>
 			

--- a/src/help/en/MUL.htm
+++ b/src/help/en/MUL.htm
@@ -1,24 +1,26 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>MUL.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> MUL-Unsigned Multiplication of AL or AX<br>
-			<strong>Arguments:</strong> DEST: any 8, 16 or 32 bit memory location or register<br>
-			<strong>Usage:</strong> MUL DEST<br>
-			<strong>Effects:</strong> MUL performs unsigned multiplication.
+<head>
+    <title>MUL.htm</title>
+</head>
 
-A byte operand is multiplied by AL; the result is left in AX. The carry and overflow flags are set to 0 if AH is 0; otherwise, they areset to 1.
+<body>
+<div style="font-family: Helvetica,Arial,sans-serif; font-size: 11px;">
+    <strong>Command:</strong> MUL (Unsigned Multiplication of AL, AX or EAX)<br>
 
-A word operand is multiplied by AX; the result is left in DX:AX. DX contains the high-order 16 bits of the product. The carry and overflow flags are set to 0 if DX is 0; otherwise, they are set to 1.
+    <strong>Usage:</strong> MUL DEST<br>
 
-A doubleword operand is multiplied by EAX and the result is left in EDX:EAX. EDX contains the high-order 32 bits of the product. The carry and overflow flags are set to 0 if EDX is 0; otherwise, they are set to 1.
-<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF and CF as described; SF, ZF, AF, PF, and CF are undefined
-			
-			</body>
-			</html>
+    <strong>Arguments:</strong> DEST: Any 8, 16 or 32 bit memory location or register<br>
+
+    <strong>Effects:</strong> MUL performs unsigned multiplication.<br>
+    A byte operand is multiplied by AL; the result is left in AX. The carry and overflow flags are set to 0 if AH is 0; otherwise, they are set to 1.<br>
+    A word operand is multiplied by AX; the result is left in DX:AX. DX contains the high-order 16 bits of the product. The carry and overflow flags are set to 0 if DX is 0; otherwise, they are set to 1.<br>
+    A doubleword operand is multiplied by EAX; the result is left in EDX:EAX. EDX contains the high-order 32 bits of the product. The carry and overflow flags are set to 0 if EDX is 0; otherwise, they are set to 1.
+    <br>
+
+    <strong>Flags to be set:</strong> OF and CF as described; SF, ZF, AF, PF, and CF are undefined<br>
+</div>
+</body>
+</html>
 			

--- a/src/help/en/NEG.htm
+++ b/src/help/en/NEG.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>NEG.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> NEG-Two's Complement Negation<br>
-			<strong>Arguments:</strong> DEST: any 8, 16 or 32 bit memory location or register<br>
-			<strong>Usage:</strong> NED GEST<br>
-			<strong>Effects:</strong> Deplace DEST with its two's complement (The operand is subtracted from zero).<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=1 when DEST!=0 else CF=0; OF, SF, ZF, and PF according to the result
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>NEG.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> NEG-Two's Complement Negation<br>
+    <strong>Arguments:</strong> DEST: any 8, 16 or 32 bit memory location or register<br>
+    <strong>Usage:</strong> NED GEST<br>
+    <strong>Effects:</strong> Deplace DEST with its two's complement (The operand is subtracted from zero).<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF=1 when DEST!=0 else CF=0; OF, SF, ZF, and PF according to the result
+</div>
+</body>
+</html>
 			

--- a/src/help/en/NOP.htm
+++ b/src/help/en/NOP.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>NOP.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> NOP-No Operation<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> NOP<br>
-			<strong>Effects:</strong> none, except that (E)IP is incremented.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> NOP is an alias mnemonic for the XCHG (E)AX, (E)AX instruction.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>NOP.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> NOP-No Operation<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> NOP<br>
+    <strong>Effects:</strong> none, except that (E)IP is incremented.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> NOP is an alias mnemonic for the XCHG (E)AX, (E)AX instruction.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/NOT.htm
+++ b/src/help/en/NOT.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>NOT.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> NOT-One's Complement Negation<br>
-			<strong>Arguments:</strong> DEST: any 8, 16 or 32 bit memory location or register<br>
-			<strong>Usage:</strong> NOT DEST<br>
-			<strong>Effects:</strong> Invert DEST. (0->1 and 1->0)<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>NOT.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> NOT-One's Complement Negation<br>
+    <strong>Arguments:</strong> DEST: any 8, 16 or 32 bit memory location or register<br>
+    <strong>Usage:</strong> NOT DEST<br>
+    <strong>Effects:</strong> Invert DEST. (0->1 and 1->0)<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/OR.htm
+++ b/src/help/en/OR.htm
@@ -1,19 +1,18 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>OR.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> OR - Logical or<br>
+    <strong>Arguments:</strong> DEST: register or memory location; SRC: immediate, register or memory location; (two memory operands cannot be used in one instruction)<br>
+    <strong>Usage:</strong> OR DEST,SRC<br>
+    <strong>Effects:</strong> DEST := DEST or SRC
+    Performs bitwise or of DEST and SRC
+    <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF, ZF, SF, ZF, PF
 
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>OR.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> OR - Logical or<br>
-			<strong>Arguments:</strong> DEST: register or memory location; SRC: immediate, register or memory location; (two memory operands cannot be used in one instruction)<br>
-			<strong>Usage:</strong> OR DEST,SRC<br>
-			<strong>Effects:</strong> DEST := DEST or SRC
-Performs bitwise or of DEST and SRC
-<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF, ZF, SF, ZF, PF
-			
-			</body>
-			</html>
+</body>
+</html>
 			

--- a/src/help/en/POP.htm
+++ b/src/help/en/POP.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>POP.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> POP-Pop a Word from the Stack<br>
-			<strong>Arguments:</strong> DEST 16 or 32 bit memory location or register or segment register<br>
-			<strong>Usage:</strong> POP DEST<br>
-			<strong>Effects:</strong> POP stores the contents of DEST with the word on the top of the 80386 stack, addressed by SS:SP (address-size attribute of 16 bits) or SS:ESP (addresssize attribute of 32 bits). The stack pointer is then increased accordingly.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>POP.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> POP-Pop a Word from the Stack<br>
+    <strong>Arguments:</strong> DEST 16 or 32 bit memory location or register or segment register<br>
+    <strong>Usage:</strong> POP DEST<br>
+    <strong>Effects:</strong> POP stores the contents of DEST with the word on the top of the 80386 stack, addressed by SS:SP (address-size attribute of 16 bits) or SS:ESP (addresssize attribute of 32 bits). The stack pointer is then increased accordingly.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/POPA.htm
+++ b/src/help/en/POPA.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>POPA.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> POPA-Pop all General Registers<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> POPA<br>
-			<strong>Effects:</strong> Pop the eight 16-bit general registers to their values before PUSHA was executed. The first register popped is DI.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> SP value is discarded instead of loaded into SP.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>POPA.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> POPA-Pop all General Registers<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> POPA<br>
+    <strong>Effects:</strong> Pop the eight 16-bit general registers to their values before PUSHA was executed. The first register popped is DI.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> SP value is discarded instead of loaded into SP.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/POPAD.htm
+++ b/src/help/en/POPAD.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>POPAD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> POPAD-Pop all General Registers<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> POPAD<br>
-			<strong>Effects:</strong> Pop the eight 32-bit general registers to their values before PUSHA was executed. The first register popped is EDI.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> ESP value is discarded instead of loaded into SP.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>POPAD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> POPAD-Pop all General Registers<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> POPAD<br>
+    <strong>Effects:</strong> Pop the eight 32-bit general registers to their values before PUSHA was executed. The first register popped is EDI.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> ESP value is discarded instead of loaded into SP.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/POPF.htm
+++ b/src/help/en/POPF.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>POPF.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> POPF-Pop Stack into FLAGS or EFLAGS Register<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> POPF<br>
-			<strong>Effects:</strong> Pop the word on top of stack and store it to the FLAGS register.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>POPF.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> POPF-Pop Stack into FLAGS or EFLAGS Register<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> POPF<br>
+    <strong>Effects:</strong> Pop the word on top of stack and store it to the FLAGS register.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/POPFD.htm
+++ b/src/help/en/POPFD.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>POPFD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> POPFD-Pop Stack into FLAGS or EFLAGS Register<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> POPFD<br>
-			<strong>Effects:</strong> Pop the dword on top of stack and store it to the EFLAGS register.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> bits 16 and 17 of EFLAGS are not affected.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>POPFD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> POPFD-Pop Stack into FLAGS or EFLAGS Register<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> POPFD<br>
+    <strong>Effects:</strong> Pop the dword on top of stack and store it to the EFLAGS register.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> bits 16 and 17 of EFLAGS are not affected.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/PUSH.htm
+++ b/src/help/en/PUSH.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>PUSH.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> PUSH-Push Operand onto the Stack<br>
-			<strong>Arguments:</strong> 16 or 32 bit immediate, register or memory location<br>
-			<strong>Usage:</strong> PUSH SRC<br>
-			<strong>Effects:</strong> Depending on the operand size, decrease stack pointer by 2 or 4 and copy SRC to top of stack<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>PUSH.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> PUSH-Push Operand onto the Stack<br>
+    <strong>Arguments:</strong> 16 or 32 bit immediate, register or memory location<br>
+    <strong>Usage:</strong> PUSH SRC<br>
+    <strong>Effects:</strong> Depending on the operand size, decrease stack pointer by 2 or 4 and copy SRC to top of stack<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/PUSHA.htm
+++ b/src/help/en/PUSHA.htm
@@ -1,18 +1,18 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>PUSHA.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> PUSHA-Push all General Registers<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> PUSHA<br>
-			<strong>Effects:</strong> Decrement stack pointer by 16 and push the 16 bit general registers onto the stack.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> The registers are pushed in the following order
-AX, CX, DX, BX, SP, BP, SI, DI</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>PUSHA.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> PUSHA-Push all General Registers<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> PUSHA<br>
+    <strong>Effects:</strong> Decrement stack pointer by 16 and push the 16 bit general registers onto the stack.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> The registers are pushed in the following order
+    AX, CX, DX, BX, SP, BP, SI, DI
+</div>
+</body>
+</html>
 			

--- a/src/help/en/PUSHAD.htm
+++ b/src/help/en/PUSHAD.htm
@@ -1,18 +1,18 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>PUSHAD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> PUSHAD-Push all General Registers<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> PUSHAD<br>
-			<strong>Effects:</strong> Decrement stack pointer by 32 and push the 32 bit general registers onto the stack.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> The registers are pushed in the following order
-EAX, ECX, EDX, EBX, ESP, EBP, ESI, EDI</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>PUSHAD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> PUSHAD-Push all General Registers<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> PUSHAD<br>
+    <strong>Effects:</strong> Decrement stack pointer by 32 and push the 32 bit general registers onto the stack.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> The registers are pushed in the following order
+    EAX, ECX, EDX, EBX, ESP, EBP, ESI, EDI
+</div>
+</body>
+</html>
 			

--- a/src/help/en/PUSHF.htm
+++ b/src/help/en/PUSHF.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>PUSHF.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> PUSHF-Push Flags Register onto the Stack<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> PUSHF<br>
-			<strong>Effects:</strong> decrements the stack pointer by 2, and copies the FLAGS register to the new top of stac<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>PUSHF.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> PUSHF-Push Flags Register onto the Stack<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> PUSHF<br>
+    <strong>Effects:</strong> decrements the stack pointer by 2, and copies the FLAGS register to the new top of stac<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/PUSHFD.htm
+++ b/src/help/en/PUSHFD.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>PUSHFD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> PUSHFD-Push Flags Register onto the Stack<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> PUSHFD<br>
-			<strong>Effects:</strong> decrements the stack pointer by 4, and copies the 80386 EFLAGS register to the new top of stac<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>PUSHFD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> PUSHFD-Push Flags Register onto the Stack<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> PUSHFD<br>
+    <strong>Effects:</strong> decrements the stack pointer by 4, and copies the 80386 EFLAGS register to the new top of stac<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/RCL.htm
+++ b/src/help/en/RCL.htm
@@ -1,18 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>RCL.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> RCL - Rotate left through Carry<br>
-			<strong>Arguments:</strong> DEST: register or memory location, COUNT: 1, register CL or immidiate<br>
-			<strong>Usage:</strong> RCL DEST, COUNT<br>
-			<strong>Effects:</strong> Rotates DEST together with carry bit COUNT times to the left<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF
-			<br><strong>Misc:</strong> Example: in the operation RCL AL,1, a 9-bit rotation is performed in which AL is shifted left by 1, the top bit of AL moves into the carry flag, and the original value of the carry flag is placed in the low bit of AL.
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>RCL.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> RCL - Rotate left through Carry<br>
+    <strong>Arguments:</strong> DEST: register or memory location, COUNT: 1, register CL or immidiate<br>
+    <strong>Usage:</strong> RCL DEST, COUNT<br>
+    <strong>Effects:</strong> Rotates DEST together with carry bit COUNT times to the left<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF
+    <br><strong>Misc:</strong> Example: in the operation RCL AL,1, a 9-bit rotation is performed in which AL is shifted left by 1, the top bit of AL moves into the carry flag, and the original value of the carry flag is placed in the low bit of AL.
 </div>
-			</body>
-			</html>
+</body>
+</html>
 			

--- a/src/help/en/RCR.htm
+++ b/src/help/en/RCR.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>RCR.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> RCR - Rotate right through Carry<br>
-			<strong>Arguments:</strong> DEST: register or memory location, COUNT: 1, register CL or immidiate<br>
-			<strong>Usage:</strong> RCR DEST, COUNT<br>
-			<strong>Effects:</strong> Rotates DEST together with carry bit COUNT times to the right.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF
-			<br><strong>Misc:</strong> See an exmple at RCL</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>RCR.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> RCR - Rotate right through Carry<br>
+    <strong>Arguments:</strong> DEST: register or memory location, COUNT: 1, register CL or immidiate<br>
+    <strong>Usage:</strong> RCR DEST, COUNT<br>
+    <strong>Effects:</strong> Rotates DEST together with carry bit COUNT times to the right.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF
+    <br><strong>Misc:</strong> See an exmple at RCL
+</div>
+</body>
+</html>
 			

--- a/src/help/en/RESB.htm
+++ b/src/help/en/RESB.htm
@@ -1,19 +1,18 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>RESB.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> RESB - Pseudo: Declaring one or more uninitialised bytes<br>
-			<strong>Arguments:</strong> COUNT: number of bytes that should be reserved<br>
-			<strong>Usage:</strong> RESB COUNT<br>
-			<strong>Effects:</strong> Reserves COUNT bytes in memory<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> Example:
-buffer: resb 64   ; reserve 64 bytes 
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>RESB.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> RESB - Pseudo: Declaring one or more uninitialised bytes<br>
+    <strong>Arguments:</strong> COUNT: number of bytes that should be reserved<br>
+    <strong>Usage:</strong> RESB COUNT<br>
+    <strong>Effects:</strong> Reserves COUNT bytes in memory<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> Example:
+    buffer: resb 64 ; reserve 64 bytes
 </div>
-			</body>
-			</html>
+</body>
+</html>
 			

--- a/src/help/en/RESD.htm
+++ b/src/help/en/RESD.htm
@@ -1,18 +1,18 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>RESD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> RESD - Pseudo: Declaring one or more uninitialised doublewords<br>
-			<strong>Arguments:</strong> COUNT: number of doublewords that should be reserved<br>
-			<strong>Usage:</strong> RESD COUNT<br>
-			<strong>Effects:</strong> Reserves COUNT doublewords in memory<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> Example:
-buffer: resw 10   ; reserve 10 doublewords</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>RESD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> RESD - Pseudo: Declaring one or more uninitialised doublewords<br>
+    <strong>Arguments:</strong> COUNT: number of doublewords that should be reserved<br>
+    <strong>Usage:</strong> RESD COUNT<br>
+    <strong>Effects:</strong> Reserves COUNT doublewords in memory<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> Example:
+    buffer: resw 10 ; reserve 10 doublewords
+</div>
+</body>
+</html>
 			

--- a/src/help/en/RESQ.htm
+++ b/src/help/en/RESQ.htm
@@ -1,18 +1,18 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>RESQ.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> RESQ - Pseudo: Declaring one or more uninitialised double-precision floats<br>
-			<strong>Arguments:</strong> COUNT: number of double-precision floats that should be reserved<br>
-			<strong>Usage:</strong> RESQ COUNT<br>
-			<strong>Effects:</strong> Reserves COUNT double-precision floats in memory<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> Example:
-realarray   resq    10   ; array of ten reals</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>RESQ.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> RESQ - Pseudo: Declaring one or more uninitialised double-precision floats<br>
+    <strong>Arguments:</strong> COUNT: number of double-precision floats that should be reserved<br>
+    <strong>Usage:</strong> RESQ COUNT<br>
+    <strong>Effects:</strong> Reserves COUNT double-precision floats in memory<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> Example:
+    realarray resq 10 ; array of ten reals
+</div>
+</body>
+</html>
 			

--- a/src/help/en/RESW.htm
+++ b/src/help/en/RESW.htm
@@ -1,18 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>RESW.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> RESW - Pseudo: Declaring one or more uninitialised words<br>
-			<strong>Arguments:</strong> COUNT: number of words that should be reserved<br>
-			<strong>Usage:</strong> RESW COUNT<br>
-			<strong>Effects:</strong> Reserves COUNT words in memory<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> wordvar:  resw   1  ; reserve a word 
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>RESW.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> RESW - Pseudo: Declaring one or more uninitialised words<br>
+    <strong>Arguments:</strong> COUNT: number of words that should be reserved<br>
+    <strong>Usage:</strong> RESW COUNT<br>
+    <strong>Effects:</strong> Reserves COUNT words in memory<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> wordvar: resw 1 ; reserve a word
 </div>
-			</body>
-			</html>
+</body>
+</html>
 			

--- a/src/help/en/RET.htm
+++ b/src/help/en/RET.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>RET.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> RET-Return from Procedure<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> RET<br>
-			<strong>Effects:</strong> Transfers program control to a return address located on the top of the stack.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> Usally the address was placed on stack by a call instrucion and the return is made to the address that follows the call instruction.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>RET.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> RET-Return from Procedure<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> RET<br>
+    <strong>Effects:</strong> Transfers program control to a return address located on the top of the stack.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> Usally the address was placed on stack by a call instrucion and the return is made to the address that follows the call instruction.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/ROL.htm
+++ b/src/help/en/ROL.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>ROL.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> ROL-Rotate left<br>
-			<strong>Arguments:</strong> DEST: register, COUNT immediate number<br>
-			<strong>Usage:</strong> ROL DEST,COUNT<br>
-			<strong>Effects:</strong> Rotates bits in DEST by COUNT to the left. Bits pushed out on one side reenter on the other. Carry flag will be set to the last bit rotated out.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF and CF as described
-			<br><strong>Misc:</strong> opposite of ROR</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>ROL.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> ROL-Rotate left<br>
+    <strong>Arguments:</strong> DEST: register, COUNT immediate number<br>
+    <strong>Usage:</strong> ROL DEST,COUNT<br>
+    <strong>Effects:</strong> Rotates bits in DEST by COUNT to the left. Bits pushed out on one side reenter on the other. Carry flag will be set to the last bit rotated out.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF and CF as described
+    <br><strong>Misc:</strong> opposite of ROR
+</div>
+</body>
+</html>
 			

--- a/src/help/en/ROR.htm
+++ b/src/help/en/ROR.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>ROR.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> ROR-Rotate right<br>
-			<strong>Arguments:</strong> DEST: register, COUNT immediate number<br>
-			<strong>Usage:</strong> ROR DEST,COUNT<br>
-			<strong>Effects:</strong> Rotates bits in DEST by COUNT to the right. Bits pushed out on one side reenter on the other. Carry flag will be set to the last bit rotated out.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF and CF as described-
-			<br><strong>Misc:</strong> opposite of ROL</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>ROR.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> ROR-Rotate right<br>
+    <strong>Arguments:</strong> DEST: register, COUNT immediate number<br>
+    <strong>Usage:</strong> ROR DEST,COUNT<br>
+    <strong>Effects:</strong> Rotates bits in DEST by COUNT to the right. Bits pushed out on one side reenter on the other. Carry flag will be set to the last bit rotated out.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF and CF as described-
+    <br><strong>Misc:</strong> opposite of ROL
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SAHF.htm
+++ b/src/help/en/SAHF.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SAHF.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SAHF - Store AH Register into FLAGS<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> SHAF<br>
-			<strong>Effects:</strong> CF, OF, PF, SF, ZF, are restored (AF undefined)<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF, PF, SF, ZF, are restored
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SAHF.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SAHF - Store AH Register into FLAGS<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> SHAF<br>
+    <strong>Effects:</strong> CF, OF, PF, SF, ZF, are restored (AF undefined)<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF, PF, SF, ZF, are restored
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SAL.htm
+++ b/src/help/en/SAL.htm
@@ -1,19 +1,19 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SAL.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SAL- Shift arithmetic left<br>
-			<strong>Arguments:</strong> OP: register or memory location; QUANTITY: immediate<br>
-			<strong>Usage:</strong> SAL OP, QUANTITY<br>
-			<strong>Effects:</strong> Shifts all bits of OP left QUANTITY times and adds a 0 at the beginning.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF, SF, ZF, PF, CF
-			<br><strong>Misc:</strong> Same as SHL
-Carry flag contains bit that was shifted out last.
-Corresponds to multiply by 2 QUANTITY times</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SAL.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SAL- Shift arithmetic left<br>
+    <strong>Arguments:</strong> OP: register or memory location; QUANTITY: immediate<br>
+    <strong>Usage:</strong> SAL OP, QUANTITY<br>
+    <strong>Effects:</strong> Shifts all bits of OP left QUANTITY times and adds a 0 at the beginning.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF, SF, ZF, PF, CF
+    <br><strong>Misc:</strong> Same as SHL
+    Carry flag contains bit that was shifted out last.
+    Corresponds to multiply by 2 QUANTITY times
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SAR.htm
+++ b/src/help/en/SAR.htm
@@ -1,18 +1,18 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SAR.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SAR- Shift arithmetic right<br>
-			<strong>Arguments:</strong> OP: register or memory location; QUANTITY: immediate<br>
-			<strong>Usage:</strong> SAR OP, QUANTITY<br>
-			<strong>Effects:</strong> Shifts all bits of OP right QUANTITY times and adds doubles the bit at the beginning.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF, SF, ZF, PF, CF
-			<br><strong>Misc:</strong> Carry flag contains bit that was shifted out last.
-Corresponds to signed division by 2 QUANTITY times</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SAR.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SAR- Shift arithmetic right<br>
+    <strong>Arguments:</strong> OP: register or memory location; QUANTITY: immediate<br>
+    <strong>Usage:</strong> SAR OP, QUANTITY<br>
+    <strong>Effects:</strong> Shifts all bits of OP right QUANTITY times and adds doubles the bit at the beginning.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF, SF, ZF, PF, CF
+    <br><strong>Misc:</strong> Carry flag contains bit that was shifted out last.
+    Corresponds to signed division by 2 QUANTITY times
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SBB.htm
+++ b/src/help/en/SBB.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SBB.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SBB-Integer Subtraction with Borrow<br>
-			<strong>Arguments:</strong> DEST: register or memory location; SRC: immediate, register or memory location<br>
-			<strong>Usage:</strong> SBB DEST,SRC<br>
-			<strong>Effects:</strong> DEST:=DEST-(SRC+CF)<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The OF, SF, ZF, AF, CF, and PF flags are set according to the result.
-			<br><strong>Misc:</strong> two memory operands cannot be used in one instruction</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SBB.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SBB-Integer Subtraction with Borrow<br>
+    <strong>Arguments:</strong> DEST: register or memory location; SRC: immediate, register or memory location<br>
+    <strong>Usage:</strong> SBB DEST,SRC<br>
+    <strong>Effects:</strong> DEST:=SRC-(DEST+CF)<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The OF, SF, ZF, AF, CF, and PF flags are set according to the result.
+    <br><strong>Misc:</strong> two memory operands cannot be used in one instruction
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SCAS.htm
+++ b/src/help/en/SCAS.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SCAS.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SCAS - Scan string bytewise<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> SHAF<br>
-			<strong>Effects:</strong> Set flags as AUB, comparing accumulator at ES:DI incrementing DI by 1.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> AF CF OF PF SF and ZF
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SCAS.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SCAS - Scan string bytewise<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> SHAF<br>
+    <strong>Effects:</strong> Set flags as AUB, comparing accumulator at ES:DI incrementing DI by 1.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> AF CF OF PF SF and ZF
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SCASB.htm
+++ b/src/help/en/SCASB.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SCASB.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SCASB - Scan string bytewise<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> SCASB<br>
-			<strong>Effects:</strong> Set flags as AUB, comparing accumulator at ES:DI incrementing DI by 1.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> AF CF OF PF SF and ZF
-			<br><strong>Misc:</strong> same as SCAS</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SCASB.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SCASB - Scan string bytewise<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> SCASB<br>
+    <strong>Effects:</strong> Set flags as AUB, comparing accumulator at ES:DI incrementing DI by 1.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> AF CF OF PF SF and ZF
+    <br><strong>Misc:</strong> same as SCAS
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SCASD.htm
+++ b/src/help/en/SCASD.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SCASD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SCASD - Scan string dword-wise<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> SCASD<br>
-			<strong>Effects:</strong> Set flags as SUB, comparing accumulator at ES:DI incrementing DI by 4.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> AF CF OF PF SF and ZF
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SCASD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SCASD - Scan string dword-wise<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> SCASD<br>
+    <strong>Effects:</strong> Set flags as SUB, comparing accumulator at ES:DI incrementing DI by 4.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> AF CF OF PF SF and ZF
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SCASW.htm
+++ b/src/help/en/SCASW.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SCASW.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SCASW - Scan string wordwise<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> SCASW<br>
-			<strong>Effects:</strong> Set flags as SUB, comparing accumulator at ES:DI incrementing DI by 2.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> AF CF OF PF SF and ZF
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SCASW.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SCASW - Scan string wordwise<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> SCASW<br>
+    <strong>Effects:</strong> Set flags as SUB, comparing accumulator at ES:DI incrementing DI by 2.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> AF CF OF PF SF and ZF
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETA.htm
+++ b/src/help/en/SETA.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETA.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETA - Set byte if above (CF=0 and ZF=0)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETA DEST<br>
-			<strong>Effects:</strong> If (CF=0 and ZF=0) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as SETNBE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETA.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETA - Set byte if above (CF=0 and ZF=0)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETA DEST<br>
+    <strong>Effects:</strong> If (CF=0 and ZF=0) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as SETNBE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETG.htm
+++ b/src/help/en/SETG.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETG.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETG - Set byte if greater (ZF=0 and SF=OF)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETG DEST<br>
-			<strong>Effects:</strong> If (SF=OF) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as SETNLE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETG.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETG - Set byte if greater (ZF=0 and SF=OF)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETG DEST<br>
+    <strong>Effects:</strong> If (SF=OF) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as SETNLE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETGE.htm
+++ b/src/help/en/SETGE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETGE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETGE - Set byte greater equal (SF=OF)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETGE DEST<br>
-			<strong>Effects:</strong> If (SF=OF) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as SETNL</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETGE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETGE - Set byte greater equal (SF=OF)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETGE DEST<br>
+    <strong>Effects:</strong> If (SF=OF) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as SETNL
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETL.htm
+++ b/src/help/en/SETL.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETL.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETL - Set byte less (SF!=OF)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETL DEST<br>
-			<strong>Effects:</strong> If (SF!=OF) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as SETNGE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETL.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETL - Set byte less (SF!=OF)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETL DEST<br>
+    <strong>Effects:</strong> If (SF!=OF) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as SETNGE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETLE.htm
+++ b/src/help/en/SETLE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETLE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETLE - Set byte if less (ZF=1 or SF!=OF)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETLE DEST<br>
-			<strong>Effects:</strong> If (ZF=1 or SF!=OF) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as SETNG</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETLE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETLE - Set byte if less (ZF=1 or SF!=OF)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETLE DEST<br>
+    <strong>Effects:</strong> If (ZF=1 or SF!=OF) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as SETNG
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETNBE.htm
+++ b/src/help/en/SETNBE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETNBE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETNBE - Set byte if not below or equal (CF=0 and ZF=0)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETNBE DEST<br>
-			<strong>Effects:</strong> If (CF=0 and ZF=0) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as SETA</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETNBE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETNBE - Set byte if not below or equal (CF=0 and ZF=0)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETNBE DEST<br>
+    <strong>Effects:</strong> If (CF=0 and ZF=0) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as SETA
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETNC.htm
+++ b/src/help/en/SETNC.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETNC.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETNC - Set byte if not carry (CF=0)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETNC DEST<br>
-			<strong>Effects:</strong> If (CF=0) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETNC.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETNC - Set byte if not carry (CF=0)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETNC DEST<br>
+    <strong>Effects:</strong> If (CF=0) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETNE.htm
+++ b/src/help/en/SETNE.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETNE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETNE - Set byte if not equal (ZF=0)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETNE DEST<br>
-			<strong>Effects:</strong> If (ZF=0) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETNE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETNE - Set byte if not equal (ZF=0)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETNE DEST<br>
+    <strong>Effects:</strong> If (ZF=0) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETNG.htm
+++ b/src/help/en/SETNG.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETNG.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETNG - Set byte if not greater (ZF=1 or SF!=OF)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETNG DEST<br>
-			<strong>Effects:</strong> If (ZF=1 or SF!=OF) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as SETLE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETNG.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETNG - Set byte if not greater (ZF=1 or SF!=OF)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETNG DEST<br>
+    <strong>Effects:</strong> If (ZF=1 or SF!=OF) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as SETLE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETNGE.htm
+++ b/src/help/en/SETNGE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETNGE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETNGE - Set byte not greater or equal (SF!=OF)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETNGE DEST<br>
-			<strong>Effects:</strong> If (SF!=OF) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as SETL</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETNGE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETNGE - Set byte not greater or equal (SF!=OF)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETNGE DEST<br>
+    <strong>Effects:</strong> If (SF!=OF) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as SETL
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETNL.htm
+++ b/src/help/en/SETNL.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETNL.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETNL - Set byte not less (SF=OF)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETNLDEST<br>
-			<strong>Effects:</strong> If (SF=OF) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as SETGE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETNL.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETNL - Set byte not less (SF=OF)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETNLDEST<br>
+    <strong>Effects:</strong> If (SF=OF) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as SETGE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETNLE.htm
+++ b/src/help/en/SETNLE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETNLE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETNLE - Set byte not less or equal (ZF=0 and SF=OF)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETNLE DEST<br>
-			<strong>Effects:</strong> If (SF=OF) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as SETG</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETNLE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETNLE - Set byte not less or equal (ZF=0 and SF=OF)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETNLE DEST<br>
+    <strong>Effects:</strong> If (SF=OF) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as SETG
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETNO.htm
+++ b/src/help/en/SETNO.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETNO.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETNO - Set byte if not overflow (OF=0)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETNO DEST<br>
-			<strong>Effects:</strong> If (OF=0) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETNO.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETNO - Set byte if not overflow (OF=0)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETNO DEST<br>
+    <strong>Effects:</strong> If (OF=0) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETNP.htm
+++ b/src/help/en/SETNP.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETNP.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETNP - Set byte if not parity (PF=0)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETNP DEST<br>
-			<strong>Effects:</strong> If (PF=0) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as SETPO</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETNP.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETNP - Set byte if not parity (PF=0)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETNP DEST<br>
+    <strong>Effects:</strong> If (PF=0) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as SETPO
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETNS.htm
+++ b/src/help/en/SETNS.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETNS.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETNS - Set byte if not signed (SF=0)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETNS DEST<br>
-			<strong>Effects:</strong> If (SF=0) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETNS.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETNS - Set byte if not signed (SF=0)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETNS DEST<br>
+    <strong>Effects:</strong> If (SF=0) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETNZ.htm
+++ b/src/help/en/SETNZ.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETNZ.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETNZ - Set byte if not zero (ZF=0)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETNZ DEST<br>
-			<strong>Effects:</strong> If (ZF=0) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETNZ.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETNZ - Set byte if not zero (ZF=0)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETNZ DEST<br>
+    <strong>Effects:</strong> If (ZF=0) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETO.htm
+++ b/src/help/en/SETO.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETO.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETO - Set byte if signed (OF=1)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETO DEST<br>
-			<strong>Effects:</strong> If (OF=1) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETO.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETO - Set byte if signed (OF=1)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETO DEST<br>
+    <strong>Effects:</strong> If (OF=1) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETP.htm
+++ b/src/help/en/SETP.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETP.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETP - Set byte if parity (PF=1)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETP DEST<br>
-			<strong>Effects:</strong> If (PF=1) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as SETPE</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETP.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETP - Set byte if parity (PF=1)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETP DEST<br>
+    <strong>Effects:</strong> If (PF=1) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as SETPE
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETPE.htm
+++ b/src/help/en/SETPE.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETPE.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETPE - Set byte if parity even (PF=1)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETPE DEST<br>
-			<strong>Effects:</strong> If (PF=1) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as SETP</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETPE.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETPE - Set byte if parity even (PF=1)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETPE DEST<br>
+    <strong>Effects:</strong> If (PF=1) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as SETP
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETPO.htm
+++ b/src/help/en/SETPO.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETPO.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETPO - Set byte if parity odd (PF=0)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETPO DEST<br>
-			<strong>Effects:</strong> If (PF=0) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> same as SETNP</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETPO.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETPO - Set byte if parity odd (PF=0)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETPO DEST<br>
+    <strong>Effects:</strong> If (PF=0) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> same as SETNP
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETS.htm
+++ b/src/help/en/SETS.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETS.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETS - Set byte if signed (SF=1)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETS DEST<br>
-			<strong>Effects:</strong> If (SF=1) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETS.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETS - Set byte if signed (SF=1)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETS DEST<br>
+    <strong>Effects:</strong> If (SF=1) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SETZ.htm
+++ b/src/help/en/SETZ.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SETZ.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SETZ - Set byte if zero (ZF=1)<br>
-			<strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
-			<strong>Usage:</strong> SETZ DEST<br>
-			<strong>Effects:</strong> If (ZF=1) DEST := 1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SETZ.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SETZ - Set byte if zero (ZF=1)<br>
+    <strong>Arguments:</strong> DEST: 8 bit general-purpose register or memory location<br>
+    <strong>Usage:</strong> SETZ DEST<br>
+    <strong>Effects:</strong> If (ZF=1) DEST := 1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SHL.htm
+++ b/src/help/en/SHL.htm
@@ -1,19 +1,18 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SHL.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SHL- Shift logical left<br>
-			<strong>Arguments:</strong> OP: register or memory location; QUANTITY: immediate<br>
-			<strong>Usage:</strong> SHL OP, QUANTITY<br>
-			<strong>Effects:</strong> Shifts all bits of OP left QUANTITY times and adds a 0 at the beginning.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF, SF, ZF, PF, CF
-			<br><strong>Misc:</strong> Carry flag contains bit that was shifted out last.
-Corresponds to multiply by 2 QUANTITY times
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SHL.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SHL- Shift logical left<br>
+    <strong>Arguments:</strong> OP: register or memory location; QUANTITY: immediate<br>
+    <strong>Usage:</strong> SHL OP, QUANTITY<br>
+    <strong>Effects:</strong> Shifts all bits of OP left QUANTITY times and adds a 0 at the beginning.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF, SF, ZF, PF, CF
+    <br><strong>Misc:</strong> Carry flag contains bit that was shifted out last.
+    Corresponds to multiply by 2 QUANTITY times
 </div>
-			</body>
-			</html>
+</body>
+</html>
 			

--- a/src/help/en/SHLD.htm
+++ b/src/help/en/SHLD.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SHLD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SHLD - Shift left replacing with source (Double Precision Shift)<br>
-			<strong>Arguments:</strong> DEST,SRC: 16 or 32 bit registers or memory address, COUNT: CL, or immediate<br>
-			<strong>Usage:</strong> SHLD DEST,SRC,COUNT<br>
-			<strong>Effects:</strong> Shift left Dest by count bits and fill bits opened with the bits from SRC.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF PF SF ZF
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SHLD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SHLD - Shift left replacing with source (Double Precision Shift)<br>
+    <strong>Arguments:</strong> DEST,SRC: 16 or 32 bit registers or memory address, COUNT: CL, or immediate<br>
+    <strong>Usage:</strong> SHLD DEST,SRC,COUNT<br>
+    <strong>Effects:</strong> Shift left Dest by count bits and fill bits opened with the bits from SRC.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF PF SF ZF
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SHR.htm
+++ b/src/help/en/SHR.htm
@@ -1,18 +1,18 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SHR.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SHR- Shift logical right<br>
-			<strong>Arguments:</strong> OP: register or memory location; QUANTITY: immediate<br>
-			<strong>Usage:</strong> SHR OP, QUANTITY<br>
-			<strong>Effects:</strong> Shifts all bits of OP right QUANTITY times and adds a 0 at the beginning.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF, SF, ZF, PF, CF
-			<br><strong>Misc:</strong> Carry flag contains bit that was shifted out last.
-Corresponds to a unsigned division by 2 QUANTITY times</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SHR.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SHR- Shift logical right<br>
+    <strong>Arguments:</strong> OP: register or memory location; QUANTITY: immediate<br>
+    <strong>Usage:</strong> SHR OP, QUANTITY<br>
+    <strong>Effects:</strong> Shifts all bits of OP right QUANTITY times and adds a 0 at the beginning.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF, SF, ZF, PF, CF
+    <br><strong>Misc:</strong> Carry flag contains bit that was shifted out last.
+    Corresponds to a unsigned division by 2 QUANTITY times
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SHRD.htm
+++ b/src/help/en/SHRD.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SHRD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SHRD - Shift right replacing with source (Double Precision Shift)<br>
-			<strong>Arguments:</strong> DEST,SRC: 16 or 32 bit registers or memory address, COUNT: CL, or immediate<br>
-			<strong>Usage:</strong> SHRD DEST,SRC,COUNT<br>
-			<strong>Effects:</strong> Shift right Dest by count bits and fill bits opened with the bits from SRC.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF PF SF ZF
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SHRD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SHRD - Shift right replacing with source (Double Precision Shift)<br>
+    <strong>Arguments:</strong> DEST,SRC: 16 or 32 bit registers or memory address, COUNT: CL, or immediate<br>
+    <strong>Usage:</strong> SHRD DEST,SRC,COUNT<br>
+    <strong>Effects:</strong> Shift right Dest by count bits and fill bits opened with the bits from SRC.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF PF SF ZF
+</div>
+</body>
+</html>
 			

--- a/src/help/en/STC.htm
+++ b/src/help/en/STC.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>STC.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> STC - Set Carry<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> STC<br>
-			<strong>Effects:</strong> CF:=1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>STC.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> STC - Set Carry<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> STC<br>
+    <strong>Effects:</strong> CF:=1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF
+</div>
+</body>
+</html>
 			

--- a/src/help/en/STD.htm
+++ b/src/help/en/STD.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>STD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> STD - Set Direction<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> STD<br>
-			<strong>Effects:</strong> DF:=1<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> DF
-			<br><strong>Misc:</strong> DF=1 string ops go down from high to low address</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>STD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> STD - Set Direction<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> STD<br>
+    <strong>Effects:</strong> DF:=1<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> DF
+    <br><strong>Misc:</strong> DF=1 string ops go down from high to low address
+</div>
+</body>
+</html>
 			

--- a/src/help/en/STOS.htm
+++ b/src/help/en/STOS.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>STOS.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> STOS - Strore string<br>
-			<strong>Arguments:</strong> DEST:<br>
-			<strong>Usage:</strong> STOS DEST<br>
-			<strong>Effects:</strong> Store string from acccumulator to [ES:DI] and increase/decrease DI by the size of the operand depending on the DF.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> see also STOSB, STOSW and STOSD</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>STOS.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> STOS - Strore string<br>
+    <strong>Arguments:</strong> DEST:<br>
+    <strong>Usage:</strong> STOS DEST<br>
+    <strong>Effects:</strong> Store string from acccumulator to [ES:DI] and increase/decrease DI by the size of the operand depending on the DF.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> see also STOSB, STOSW and STOSD
+</div>
+</body>
+</html>
 			

--- a/src/help/en/STOSB.htm
+++ b/src/help/en/STOSB.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>STOSB.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> STOSB - Strore string (byte)<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> STOSB<br>
-			<strong>Effects:</strong> Store string from acccumulator to [ES:DI] and increase/decrease DI by 1 depending on the DF.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> see also: STOS</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>STOSB.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> STOSB - Strore string (byte)<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> STOSB<br>
+    <strong>Effects:</strong> Store string from acccumulator to [ES:DI] and increase/decrease DI by 1 depending on the DF.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> see also: STOS
+</div>
+</body>
+</html>
 			

--- a/src/help/en/STOSD.htm
+++ b/src/help/en/STOSD.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>STOSD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> STOSD - Strore string (dword)<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> STOSD<br>
-			<strong>Effects:</strong> Store string from acccumulator to [ES:DI] and increase/decrease DI by 4 depending on the DF.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> see also: STOS</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>STOSD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> STOSD - Strore string (dword)<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> STOSD<br>
+    <strong>Effects:</strong> Store string from acccumulator to [ES:DI] and increase/decrease DI by 4 depending on the DF.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> see also: STOS
+</div>
+</body>
+</html>
 			

--- a/src/help/en/STOSW.htm
+++ b/src/help/en/STOSW.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>STOSW.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> STOSW - Strore string (word)<br>
-			<strong>Arguments:</strong> none<br>
-			<strong>Usage:</strong> STOSW<br>
-			<strong>Effects:</strong> Store string from acccumulator to [ES:DI] and increase/decrease DI by 2 depending on the DF.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			<br><strong>Misc:</strong> see also: STOS</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>STOSW.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> STOSW - Strore string (word)<br>
+    <strong>Arguments:</strong> none<br>
+    <strong>Usage:</strong> STOSW<br>
+    <strong>Effects:</strong> Store string from acccumulator to [ES:DI] and increase/decrease DI by 2 depending on the DF.<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+    <br><strong>Misc:</strong> see also: STOS
+</div>
+</body>
+</html>
 			

--- a/src/help/en/SUB.htm
+++ b/src/help/en/SUB.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>SUB.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> SUB-Integer Subtraction<br>
-			<strong>Arguments:</strong> DEST: register or memory location; SRC: immediate, register or memory location<br>
-			<strong>Usage:</strong> SUB DEST,SRC<br>
-			<strong>Effects:</strong> DEST:=DEST-SRC<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong>  The OF, SF, ZF, AF, CF, and PF flags are set according to the result.
-			<br><strong>Misc:</strong> Two memory operands cannot be used in one instruction.</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>SUB.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> SUB-Integer Subtraction<br>
+    <strong>Arguments:</strong> DEST: register or memory location; SRC: immediate, register or memory location<br>
+    <strong>Usage:</strong> SUB DEST,SRC<br>
+    <strong>Effects:</strong> DEST:=DEST-SRC<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The OF, SF, ZF, AF, CF, and PF flags are set according to the result.
+    <br><strong>Misc:</strong> Two memory operands cannot be used in one instruction.
+</div>
+</body>
+</html>
 			

--- a/src/help/en/TEST.htm
+++ b/src/help/en/TEST.htm
@@ -1,17 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>TEST.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> TEST - Test For Bit Pattern<br>
-			<strong>Arguments:</strong> DEST: Register or memory location of arbitrary size, SRC: Immediate, register or memory location<br>
-			<strong>Usage:</strong> TEST DEST,SRC<br>
-			<strong>Effects:</strong> Logical (DEST AND SRC) setting the flags according to the result without storing it. <br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF, PF, SF and ZF
-			<br><strong>Misc:</strong> similar to CMP</div>
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>TEST.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> TEST - Test For Bit Pattern<br>
+    <strong>Arguments:</strong> DEST: Register or memory location of arbitrary size, SRC: Immediate, register or memory location<br>
+    <strong>Usage:</strong> TEST DEST,SRC<br>
+    <strong>Effects:</strong> Logical (DEST AND SRC) setting the flags according to the result without storing it. <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, OF, PF, SF and ZF
+    <br><strong>Misc:</strong> similar to CMP
+</div>
+</body>
+</html>
 			

--- a/src/help/en/XADD.htm
+++ b/src/help/en/XADD.htm
@@ -1,18 +1,17 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>XADD.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> XADD - Exchange and Add<br>
-			<strong>Arguments:</strong> DEST: register or memory location, SRC: register<br>
-			<strong>Usage:</strong> XADD DEST, SRC<br>
-			<strong>Effects:</strong> XADD exchanges the values in its two operands, and then adds them together and writes the result into DEST. <br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, PF, AF, SF, ZF, OF
-			<br><strong>Misc:</strong> This instruction can be used with a LOCK prefix for multi-processor synchronisation purposes.
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>XADD.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> XADD - Exchange and Add<br>
+    <strong>Arguments:</strong> DEST: register or memory location, SRC: register<br>
+    <strong>Usage:</strong> XADD DEST, SRC<br>
+    <strong>Effects:</strong> XADD exchanges the values in its two operands, and then adds them together and writes the result into DEST. <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> CF, PF, AF, SF, ZF, OF
+    <br><strong>Misc:</strong> This instruction can be used with a LOCK prefix for multi-processor synchronisation purposes.
 </div>
-			</body>
-			</html>
+</body>
+</html>
 			

--- a/src/help/en/XCHG.htm
+++ b/src/help/en/XCHG.htm
@@ -1,17 +1,16 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>XCHG.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> XCHG - Exchange register/memory with register<br>
-			<strong>Arguments:</strong> DEST: register or memory location; SRC: register or memory location; (two memory operands cannot be used)<br>
-			<strong>Usage:</strong> XCHG DEST,SRC<br>
-			<strong>Effects:</strong> Exchanges the contents of both operands<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>XCHG.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> XCHG - Exchange register/memory with register<br>
+    <strong>Arguments:</strong> DEST: register or memory location; SRC: register or memory location; (two memory operands cannot be used)<br>
+    <strong>Usage:</strong> XCHG DEST,SRC<br>
+    <strong>Effects:</strong> Exchanges the contents of both operands<br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> none
+</div>
+</body>
+</html>
 			

--- a/src/help/en/XOR.htm
+++ b/src/help/en/XOR.htm
@@ -1,19 +1,18 @@
-
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>XOR.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> XOR - Logical exclusive or<br>
-			<strong>Arguments:</strong> DEST: register or memory location; SRC: immediate, register or memory location; (two memory operands cannot be used in one instruction)<br>
-			<strong>Usage:</strong> XOR DEST,SRC<br>
-			<strong>Effects:</strong> DEST := DEST xor SRC
-Performs bitwise exclusive or of DEST and SRC
-<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF, ZF, SF, ZF, PF
-			
-			</body>
-			</html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>XOR.htm</title>
+</head>
+<body>
+<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
+    <strong>Command:</strong> XOR - Logical exclusive or<br>
+    <strong>Arguments:</strong> DEST: register or memory location; SRC: immediate, register or memory location; (two memory operands cannot be used in one instruction)<br>
+    <strong>Usage:</strong> XOR DEST,SRC<br>
+    <strong>Effects:</strong> DEST := DEST xor SRC
+    Performs bitwise exclusive or of DEST and SRC
+    <br>
+    <strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF, ZF, SF, ZF, PF
+</div>
+</body>
+</html>
 			


### PR DESCRIPTION
Os nossos colegas de Munique tiveram a gentileza de indentar o codigo respetivo aos HTMLs dos ficheiros de ajuda. Não é que ajude no nosso desenvolvimento imediato mas para um futuro Web Developer faz toda a diferença na legibilidade do código. Parece-me uma alteração segura que só oferece otimizações (não pondo qualquer integridade do código em risco).